### PR TITLE
refactor(common): organize lib into submodules

### DIFF
--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,3 +1,35 @@
-export * from './lib/common';
+export {
+  IAuthKeyPayload,
+  IAuthUser,
+  IToken,
+  signInInputObj,
+  signInInputType,
+  signUpInputObj,
+  signUpInputType,
+} from './lib/auth';
 
-export * from './lib/utils';
+export {
+  INow,
+  AddTagType,
+  PERSONINHOUSEHOLDTYPE,
+  PersonsType,
+  SettingsType,
+  SortModelType,
+  UpdateHouseholdsType,
+  UpdatePersonsType,
+  UpdateTagType,
+  getAllOptionsType,
+} from './lib/models';
+
+export {
+  AddTagObj,
+  PersonsObj,
+  SettingsObj,
+  UpdateHouseholdsObj,
+  UpdatePersonsObj,
+  UpdateTagObj,
+  sortModelItem,
+  getAllOptions,
+} from './lib/schemas';
+
+export { debounce, sleep } from './lib/utils';

--- a/common/src/lib/auth/index.ts
+++ b/common/src/lib/auth/index.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+
+/**
+ * The interface for the data that builds the authkey JWT token.
+ * All fields are required
+ */
+export interface IAuthKeyPayload {
+  /**
+   * The name of the user that is logged in.
+   */
+  name: string;
+
+  /**
+   * The session ID of the current session
+   */
+  session_id: string;
+
+  /**
+   * The tenant ID of the current user's tenant
+   */
+  tenant_id: string;
+
+  /**
+   * The user ID of the current user
+   */
+  user_id: string;
+}
+
+/**
+ * The current authenticated user.
+ */
+export interface IAuthUser {
+  /**
+   * The email address of the user that the user registered with
+   */
+  email: string;
+
+  /**
+   * The first name of the user
+   */
+  first_name: string;
+
+  /**
+   * The unique ID that is also used as the primary key in the database.
+   */
+  id: string;
+}
+
+/**
+ * The set of auth token and refresh token that are typically used
+ * to refresh the authentication token. The given auth token is
+ * typically the expired token.
+ */
+export interface IToken {
+  auth_token: string | null;
+  refresh_token: string | null;
+}
+
+/**
+ * The list of objects that are required to login a user.
+ */
+export const signInInputObj = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+export type signInInputType = z.infer<typeof signInInputObj>;
+
+/**
+ * The list of objects that are required to create a new
+ * user. All fields are required.
+ */
+export const signUpInputObj = z.object({
+  /**
+   * The name of the organization that the user belongs to.
+   * This is the new organization.
+   */
+  organization: z.string(),
+  /**
+   * The email address of the user that the user will register with.
+   * This is the new user's email address. It should be unique.
+   */
+  email: z.string().max(100),
+  /**
+   * The password of the user that the user will register with.
+   * It should be at least 8 characters long and at most 72 characters.
+   * It should also not be found in any previous data leaks.
+   */
+  password: z.string().min(8).max(72),
+  /**
+   * The first name of the user that the user will register with.
+   */
+  first_name: z.string().max(100),
+});
+export type signUpInputType = z.infer<typeof signUpInputObj>;

--- a/common/src/lib/models/index.ts
+++ b/common/src/lib/models/index.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import {
+  AddTagObj,
+  PersonsObj,
+  SettingsObj,
+  sortModelItem,
+  UpdateHouseholdsObj,
+  UpdatePersonsObj,
+  UpdateTagObj,
+  getAllOptions,
+} from '../schemas';
+
+/**
+ * Used to get the current time in string from the database
+ */
+export interface INow {
+  now: string;
+}
+
+export type AddTagType = z.infer<typeof AddTagObj>;
+
+export type PERSONINHOUSEHOLDTYPE = {
+  first_name: string;
+  full_name: string;
+  id: string;
+  last_name: string;
+  middle_names: string;
+};
+
+export type PersonsType = z.infer<typeof PersonsObj>;
+
+export type SettingsType = z.infer<typeof SettingsObj>;
+
+export type SortModelType = z.infer<typeof sortModelItem>;
+
+export type UpdateHouseholdsType = z.infer<typeof UpdateHouseholdsObj>;
+
+export type UpdatePersonsType = z.infer<typeof UpdatePersonsObj>;
+
+export type UpdateTagType = z.infer<typeof UpdateTagObj>;
+
+export type getAllOptionsType = z.infer<typeof getAllOptions>;

--- a/common/src/lib/schemas/index.ts
+++ b/common/src/lib/schemas/index.ts
@@ -1,101 +1,6 @@
 import { z } from 'zod';
 
 /**
- * The interface for the data that builds the authkey JWT token.
- * All fields are required
- */
-export interface IAuthKeyPayload {
-  /**
-   * The name of the user that is logged in.
-   */
-  name: string;
-
-  /**
-   * The session ID of the current session
-   */
-  session_id: string;
-
-  /**
-   * The tenant ID of the current user's tenant
-   */
-  tenant_id: string;
-
-  /**
-   * The user ID of the current user
-   */
-  user_id: string;
-}
-
-/**
- * The current authenticated user.
- */
-export interface IAuthUser {
-  /**
-   * The email address of the user that the user registered with
-   */
-  email: string;
-
-  /**
-   * The first name of the user
-   */
-  first_name: string;
-
-  /**
-   * The unique ID that is also used as the primary key in the database.
-   */
-  id: string;
-}
-
-/**
- * Used to get the current time in string from the database
- */
-export interface INow {
-  now: string;
-}
-
-/**
- * The set of auth token and refresh token that are typically used
- * to refresh the authentication token. The given auth token is
- * typically the expired token.
- */
-export interface IToken {
-  auth_token: string | null;
-  refresh_token: string | null;
-}
-
-export type AddTagType = z.infer<typeof AddTagObj>;
-
-export type PERSONINHOUSEHOLDTYPE = {
-  first_name: string;
-  full_name: string;
-  id: string;
-  last_name: string;
-  middle_names: string;
-};
-
-export type PersonsType = z.infer<typeof PersonsObj>;
-
-export type SettingsType = z.infer<typeof SettingsObj>;
-
-export type SortModelType = z.infer<typeof sortModelItem>;
-
-export type UpdateHouseholdsType = z.infer<typeof UpdateHouseholdsObj>;
-
-export type UpdatePersonsType = z.infer<typeof UpdatePersonsObj>;
-
-export type UpdateTagType = z.infer<typeof UpdateTagObj>;
-
-export type getAllOptionsType = z.infer<typeof getAllOptions>;
-
-export type signInInputType = z.infer<typeof signInInputObj>;
-
-export type signUpInputType = z.infer<typeof signUpInputObj>;
-
-export function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
  * The list of objects that are required to create a new
  * tag.
  */
@@ -130,6 +35,7 @@ export const PersonsObj = z.object({
   notes: z.string(),
   json: z.string(),
 });
+
 export const SettingsObj = z.object({
   id: z.string().optional(),
   tenant_id: z.string().optional(),
@@ -139,6 +45,7 @@ export const SettingsObj = z.object({
   key: z.string().optional(),
   value: z.object().optional(),
 });
+
 export const UpdateHouseholdsObj = z.object({
   home_phone: z.string().optional(),
   street_num: z.string().optional(),
@@ -151,6 +58,7 @@ export const UpdateHouseholdsObj = z.object({
   notes: z.string().optional(),
   json: z.string().optional(),
 });
+
 export const UpdatePersonsObj = z.object({
   campaign_id: z.string().optional(),
   household_id: z.string().optional(),
@@ -182,6 +90,7 @@ export const UpdateTagObj = z.object({
    */
   description: z.string().nullable().optional(),
 });
+
 export const sortModelItem = z
   .object({
     colId: z.string(),
@@ -226,39 +135,3 @@ export const getAllOptions = z
     tags: z.array(z.string()).optional(),
   })
   .optional();
-
-/**
- * The list of objects that are required to login a user.
- */
-export const signInInputObj = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-});
-
-/**
- * The list of objects that are required to create a new
- * user. All fields are required.
- * @see signUpInputType
- */
-export const signUpInputObj = z.object({
-  /**
-   * The name of the organization that the user belongs to.
-   * This is the new organization.
-   */
-  organization: z.string(),
-  /**
-   * The email address of the user that the user will register with.
-   * This is the new user's email address. It should be unique.
-   */
-  email: z.string().max(100),
-  /**
-   * The password of the user that the user will register with.
-   * It should be at least 8 characters long and at most 72 characters.
-   * It should also not be found in any previous data leaks.
-   */
-  password: z.string().min(8).max(72),
-  /**
-   * The first name of the user that the user will register with.
-   */
-  first_name: z.string().max(100),
-});

--- a/common/src/lib/utils/index.ts
+++ b/common/src/lib/utils/index.ts
@@ -5,3 +5,7 @@ export function debounce<F extends (...args: any[]) => void>(fn: F, delay = 300)
     timeout = setTimeout(() => fn(...args), delay);
   };
 }
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- split common utilities and types into auth, models, schemas, and utils submodules
- move interfaces and Zod schemas from monolithic file into new modules
- replace wildcard exports with explicit re-exports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing parameter 'recommendedConfig' in FlatCompat constructor)*

------
https://chatgpt.com/codex/tasks/task_e_689526a6cc348321a321e21d0bb84618