### PR TITLE
feat: enable basic REST GET endpoints

### DIFF
--- a/apps/backend/src/app/routes/auth/auth.route.ts
+++ b/apps/backend/src/app/routes/auth/auth.route.ts
@@ -1,12 +1,20 @@
-import { FastifyPluginCallback } from 'fastify';
+import { FastifyPluginCallback, FastifyRequest } from 'fastify';
+
+import { AuthController } from '../../controllers/auth.controller';
+import { IdParam } from '../fastify.types';
+
+const auth = new AuthController();
 
 /**
- * No public HTTP routes for authentication
- * @param fastify
- * @param _
- * @param done
+ * Supported HTTP routes for the auth endpoint
  */
-const routes: FastifyPluginCallback = (_fastify, _, done) => {
+const routes: FastifyPluginCallback = (fastify, _, done) => {
+  fastify.get('', (req: FastifyRequest) => auth.getAll(req.headers['tenant-id'] as string));
+  fastify.get('/:id', (req: IdParam) =>
+    auth.getById({ tenant_id: req.headers['tenant-id'] as string, id: req.params.id }),
+  );
+  fastify.get('/count', (req: FastifyRequest) => auth.getCount(req.headers['tenant-id'] as string));
+
   done();
 };
 

--- a/apps/backend/src/app/routes/households/households.route.ts
+++ b/apps/backend/src/app/routes/households/households.route.ts
@@ -1,18 +1,24 @@
-import { FastifyPluginCallback } from 'fastify';
+import { FastifyPluginCallback, FastifyRequest } from 'fastify';
 
-// const households = new HouseholdsController();
+import { HouseholdsController } from '../../controllers/households.controller';
+import * as schema from './households.schema';
+import { IdParam } from '../fastify.types';
+
+const households = new HouseholdsController();
 
 /**
  * Supported HTTP routes for the households endpoint
  */
-const routes: FastifyPluginCallback = (_fastify, _, done) => {
-  /*
-  fastify.get('', schema.getAll, () => households.getAll());
-
-  fastify.get('/:id', schema.findFromId, (req: IdParam) => households.getById(req.params.id));
-  fastify.get('/count', schema.count, () => households.getCount());
-  fastify.delete('/:id', schema.findFromId, (req: IdParam) => households.delete(req.params.id));
-  */
+const routes: FastifyPluginCallback = (fastify, _, done) => {
+  fastify.get('', schema.getAll, (req: FastifyRequest) =>
+    households.getAll(req.headers['tenant-id'] as string),
+  );
+  fastify.get('/:id', schema.findFromId, (req: IdParam) =>
+    households.getById({ tenant_id: req.headers['tenant-id'] as string, id: req.params.id }),
+  );
+  fastify.get('/count', schema.count, (req: FastifyRequest) =>
+    households.getCount(req.headers['tenant-id'] as string),
+  );
 
   done();
 };

--- a/apps/backend/src/app/routes/persons/persons.route.ts
+++ b/apps/backend/src/app/routes/persons/persons.route.ts
@@ -1,24 +1,25 @@
-import { FastifyPluginCallback } from 'fastify';
+import { FastifyPluginCallback, FastifyRequest } from 'fastify';
 
-//const persons = new PersonsController();
+import { PersonsController } from '../../controllers/persons.controller';
+import * as schema from './persons.schema';
+import { IdParam } from '../fastify.types';
+
+const persons = new PersonsController();
 
 /**
  * Supported HTTP routes for the persons endpoint
  */
-const routes: FastifyPluginCallback = (_fastify, _, done) => {
-  /*
-  fastify.get('', schema.getAll, () => persons.getAll());
+const routes: FastifyPluginCallback = (fastify, _, done) => {
+  fastify.get('', schema.getAll, (req: FastifyRequest) =>
+    persons.getAll(req.headers['tenant-id'] as string),
+  );
+  fastify.get('/:id', schema.findFromId, (req: IdParam) =>
+    persons.getById({ tenant_id: req.headers['tenant-id'] as string, id: req.params.id }),
+  );
+  fastify.get('/count', schema.count, (req: FastifyRequest) =>
+    persons.getCount(req.headers['tenant-id'] as string),
+  );
 
-  fastify.get('/:id', schema.findFromId, (req: IdParam) => persons.getById(req.params.id));
-  fastify.get('/count', schema.count, () => persons.getCount());
-  fastify.post('', schema.update, (req) =>
-    persons.add(req.body as OperationDataType<'persons', 'insert'>),
-  );
-  fastify.patch('/:id', schema.findFromId, (req: IdParam) =>
-    persons.update(req.params.id, req.body as OperationDataType<'persons', 'insert'>),
-  );
-  fastify.delete('/:id', schema.findFromId, (req: IdParam) => persons.delete(req.params.id));
-*/
   done();
 };
 


### PR DESCRIPTION
## Summary
- enable GET, GET/:id, and /count endpoints for auth
- expose GET, GET/:id, and /count endpoints for households
- expose GET, GET/:id, and /count endpoints for persons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing parameter 'recommendedConfig' in FlatCompat constructor.)*

------
https://chatgpt.com/codex/tasks/task_e_689536ea642c8321b4f392ba1131015a