### PR TITLE
fix: respect conflict column in addOrGet

### DIFF
--- a/apps/backend/src/app/repositories/base.repo.ts
+++ b/apps/backend/src/app/repositories/base.repo.ts
@@ -117,7 +117,10 @@ export class BaseRepository<T extends keyof Models> {
     }
 
     const lhs = input.onConflictColumn as ReferenceExpression<Models, T>;
-    return this.getSelect(trx).selectAll().where(lhs, '=', input.row['name']).executeTakeFirst() as unknown as
+    return this.getSelect(trx)
+      .selectAll()
+      .where(lhs, '=', matchValue)
+      .executeTakeFirst() as unknown as
       | Models[T]
       | undefined;
   }


### PR DESCRIPTION
## Summary
- fix BaseRepository.addOrGet to query using the specified conflict column value

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing parameter 'recommendedConfig' in FlatCompat constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68952577a7f08321b3a7ba2c6697c1d7