### PR TITLE
Add backend REST and TRPC tests

### DIFF
--- a/apps/backend/jest.config.ts
+++ b/apps/backend/jest.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  displayName: 'backend',
+  preset: '../../jest.preset.cjs',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.spec.json', useESM: true, diagnostics: false },
+    ],
+  },
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^@common$': '<rootDir>/../../common/src/index.ts',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/apps/backend',
+};
+
+export default config;

--- a/apps/backend/src/app/routes/persons/persons.route.spec.ts
+++ b/apps/backend/src/app/routes/persons/persons.route.spec.ts
@@ -1,0 +1,44 @@
+import Fastify from 'fastify';
+import { PersonsController } from '../../controllers/persons.controller';
+
+describe('persons REST routes', () => {
+  const tenantId = 'tenant-1';
+  let app: ReturnType<typeof Fastify>;
+  const rows = [{ id: '1', first_name: 'Alice' }];
+
+  beforeAll(async () => {
+    jest.spyOn(PersonsController.prototype, 'getAll').mockResolvedValue(rows as any);
+    jest.spyOn(PersonsController.prototype, 'getById').mockImplementation(async ({ id }) =>
+      rows.find((r) => r.id === id) as any,
+    );
+    jest.spyOn(PersonsController.prototype, 'getCount').mockResolvedValue(rows.length);
+
+    const routes = (await import('./persons.route')).default;
+    app = Fastify();
+    app.register(routes, { prefix: '/persons' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    await app.close();
+  });
+
+  it('gets all persons', async () => {
+    const res = await app.inject({ method: 'GET', url: '/persons', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(rows);
+  });
+
+  it('gets a person by id', async () => {
+    const res = await app.inject({ method: 'GET', url: '/persons/1', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(rows[0]);
+  });
+
+  it('counts persons', async () => {
+    const res = await app.inject({ method: 'GET', url: '/persons/count', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toBe(rows.length);
+  });
+});

--- a/apps/backend/src/app/trpc-routers/persons.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/persons.router.spec.ts
@@ -1,0 +1,35 @@
+import { PersonsController } from '../controllers/persons.controller';
+import { PersonsRouter } from './persons.router';
+
+describe('PersonsRouter', () => {
+  const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
+  let caller: ReturnType<typeof PersonsRouter.createCaller>;
+
+  beforeAll(() => {
+    jest.spyOn(PersonsController.prototype, 'addPerson').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(PersonsController.prototype, 'getAll').mockResolvedValue([{ id: '1' }] as any);
+    jest.spyOn(PersonsController.prototype, 'delete').mockResolvedValue(true as any);
+    jest.spyOn(PersonsController.prototype, 'getCount').mockResolvedValue(1);
+    caller = PersonsRouter.createCaller(ctx);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('adds a person', async () => {
+    await expect(caller.add({})).resolves.toEqual({ id: '1' });
+  });
+
+  it('gets all persons', async () => {
+    await expect(caller.getAll({} as any)).resolves.toEqual([{ id: '1' }]);
+  });
+
+  it('deletes a person', async () => {
+    await expect(caller.delete('1')).resolves.toBeTruthy();
+  });
+
+  it('counts persons', async () => {
+    await expect(caller.count()).resolves.toBe(1);
+  });
+});

--- a/jest.preset.cjs
+++ b/jest.preset.cjs
@@ -1,0 +1,2 @@
+const nxPreset = require('@nx/jest/preset').default;
+module.exports = { ...nxPreset };


### PR DESCRIPTION
## Summary
- configure Jest for backend with Nx preset
- test persons REST routes for basic GET endpoints
- add TRPC router tests covering add, list, delete, and count

## Testing
- `npx nx lint backend`
- `npx nx test backend --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6895425d58608321bbb90461a4d55da0