### PR TITLE
Expand backend test coverage

### DIFF
--- a/apps/backend/jest.config.ts
+++ b/apps/backend/jest.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  displayName: 'backend',
+  preset: '../../jest.preset.cjs',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.spec.json', useESM: true, diagnostics: false },
+    ],
+  },
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^@common$': '<rootDir>/../../common/src/index.ts',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/apps/backend',
+};
+
+export default config;

--- a/apps/backend/src/app/controllers/tags.controller.spec.ts
+++ b/apps/backend/src/app/controllers/tags.controller.spec.ts
@@ -1,0 +1,46 @@
+import { TagsController } from './tags.controller';
+import { TagsRepo } from '../repositories/tags.repo';
+
+describe('TagsController', () => {
+  const auth = { user_id: 'u1', tenant_id: 't1' } as any;
+  let controller: TagsController;
+
+  beforeEach(() => {
+    controller = new TagsController();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('adds a tag with tenant and user info', async () => {
+    const spy = jest.spyOn(TagsRepo.prototype, 'add').mockResolvedValue({ id: '1' } as any);
+    await controller.addTag({ name: 't', description: 'd' } as any, auth);
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][0]).toEqual({
+      row: { name: 't', description: 'd', tenant_id: 't1', createdby_id: 'u1' },
+    });
+  });
+
+  it('finds by name', async () => {
+    const spy = jest.spyOn(TagsController.prototype, 'find').mockResolvedValue([{ id: '1' }] as any);
+    await expect(controller.findByName('a', auth)).resolves.toEqual([{ id: '1' }]);
+    expect(spy).toHaveBeenCalledWith({ tenant_id: 't1', key: 'a', column: 'name' });
+  });
+
+  it('gets all with counts', async () => {
+    const spy = jest.spyOn(TagsRepo.prototype, 'getAllWithCounts').mockResolvedValue({ rows: [], count: 0 } as any);
+    await controller.getAllWithCounts(auth, {} as any);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('updates a tag with updatedby info', async () => {
+    const spy = jest.spyOn(TagsController.prototype, 'update').mockResolvedValue({ id: '1' } as any);
+    await controller.updateTag('1', { name: 'n' } as any, auth);
+    expect(spy).toHaveBeenCalledWith({
+      tenant_id: 't1',
+      id: '1',
+      row: { name: 'n', updatedby_id: 'u1' },
+    });
+  });
+});

--- a/apps/backend/src/app/repositories/tags.repo.spec.ts
+++ b/apps/backend/src/app/repositories/tags.repo.spec.ts
@@ -1,0 +1,25 @@
+import { TagsRepo } from './tags.repo';
+
+describe('TagsRepo', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('getIdByName builds proper query', async () => {
+    const repo = new TagsRepo();
+    const executeTakeFirst = jest.fn().mockResolvedValue({ id: '1' });
+    const where = jest.fn();
+    const select = jest.fn();
+    where.mockReturnValue({ where, executeTakeFirst });
+    select.mockReturnValue({ where, executeTakeFirst });
+    jest.spyOn(TagsRepo.prototype as any, 'getSelect').mockReturnValue({ select, where });
+
+    const res = await repo.getIdByName({ tenant_id: 't1', name: 'tag' });
+
+    expect(select).toHaveBeenCalledWith('id');
+    expect(where).toHaveBeenNthCalledWith(1, 'name', '=', 'tag');
+    expect(where).toHaveBeenNthCalledWith(2, 'tenant_id', '=', 't1');
+    expect(executeTakeFirst).toHaveBeenCalled();
+    expect(res).toEqual({ id: '1' });
+  });
+});

--- a/apps/backend/src/app/routes/auth/auth.route.spec.ts
+++ b/apps/backend/src/app/routes/auth/auth.route.spec.ts
@@ -1,0 +1,44 @@
+import Fastify from 'fastify';
+import { AuthController } from '../../controllers/auth.controller';
+
+describe('auth REST routes', () => {
+  const tenantId = 'tenant-1';
+  let app: ReturnType<typeof Fastify>;
+  const rows = [{ id: '1', email: 'alice@example.com' }];
+
+  beforeAll(async () => {
+    jest.spyOn(AuthController.prototype, 'getAll').mockResolvedValue(rows as any);
+    jest
+      .spyOn(AuthController.prototype, 'getById')
+      .mockImplementation(async ({ id }) => rows.find((r) => r.id === id) as any);
+    jest.spyOn(AuthController.prototype, 'getCount').mockResolvedValue(rows.length);
+
+    const routes = (await import('./auth.route')).default;
+    app = Fastify();
+    app.register(routes, { prefix: '/auth' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    await app.close();
+  });
+
+  it('gets all auth users', async () => {
+    const res = await app.inject({ method: 'GET', url: '/auth', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(rows);
+  });
+
+  it('gets an auth user by id', async () => {
+    const res = await app.inject({ method: 'GET', url: '/auth/1', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(rows[0]);
+  });
+
+  it('counts auth users', async () => {
+    const res = await app.inject({ method: 'GET', url: '/auth/count', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toBe(rows.length);
+  });
+});

--- a/apps/backend/src/app/routes/households/households.route.spec.ts
+++ b/apps/backend/src/app/routes/households/households.route.spec.ts
@@ -1,0 +1,44 @@
+import Fastify from 'fastify';
+import { HouseholdsController } from '../../controllers/households.controller';
+
+describe('households REST routes', () => {
+  const tenantId = 'tenant-1';
+  let app: ReturnType<typeof Fastify>;
+  const rows = [{ id: '1', name: 'Smith' }];
+
+  beforeAll(async () => {
+    jest.spyOn(HouseholdsController.prototype, 'getAll').mockResolvedValue(rows as any);
+    jest
+      .spyOn(HouseholdsController.prototype, 'getById')
+      .mockImplementation(async ({ id }) => rows.find((r) => r.id === id) as any);
+    jest.spyOn(HouseholdsController.prototype, 'getCount').mockResolvedValue(rows.length);
+
+    const routes = (await import('./households.route')).default;
+    app = Fastify();
+    app.register(routes, { prefix: '/households' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    await app.close();
+  });
+
+  it('gets all households', async () => {
+    const res = await app.inject({ method: 'GET', url: '/households', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(rows);
+  });
+
+  it('gets a household by id', async () => {
+    const res = await app.inject({ method: 'GET', url: '/households/1', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(rows[0]);
+  });
+
+  it('counts households', async () => {
+    const res = await app.inject({ method: 'GET', url: '/households/count', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toBe(rows.length);
+  });
+});

--- a/apps/backend/src/app/routes/persons/persons.route.spec.ts
+++ b/apps/backend/src/app/routes/persons/persons.route.spec.ts
@@ -1,0 +1,44 @@
+import Fastify from 'fastify';
+import { PersonsController } from '../../controllers/persons.controller';
+
+describe('persons REST routes', () => {
+  const tenantId = 'tenant-1';
+  let app: ReturnType<typeof Fastify>;
+  const rows = [{ id: '1', first_name: 'Alice' }];
+
+  beforeAll(async () => {
+    jest.spyOn(PersonsController.prototype, 'getAll').mockResolvedValue(rows as any);
+    jest.spyOn(PersonsController.prototype, 'getById').mockImplementation(async ({ id }) =>
+      rows.find((r) => r.id === id) as any,
+    );
+    jest.spyOn(PersonsController.prototype, 'getCount').mockResolvedValue(rows.length);
+
+    const routes = (await import('./persons.route')).default;
+    app = Fastify();
+    app.register(routes, { prefix: '/persons' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    await app.close();
+  });
+
+  it('gets all persons', async () => {
+    const res = await app.inject({ method: 'GET', url: '/persons', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(rows);
+  });
+
+  it('gets a person by id', async () => {
+    const res = await app.inject({ method: 'GET', url: '/persons/1', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(rows[0]);
+  });
+
+  it('counts persons', async () => {
+    const res = await app.inject({ method: 'GET', url: '/persons/count', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toBe(rows.length);
+  });
+});

--- a/apps/backend/src/app/trpc-routers/auth.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/auth.router.spec.ts
@@ -1,0 +1,56 @@
+import { AuthController } from '../controllers/auth.controller';
+import { AuthRouter } from './auth.router';
+
+describe('AuthRouter', () => {
+  const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
+  let caller: ReturnType<typeof AuthRouter.createCaller>;
+
+  beforeAll(() => {
+    jest.spyOn(AuthController.prototype, 'signUp').mockResolvedValue({ ok: true } as any);
+    jest.spyOn(AuthController.prototype, 'signIn').mockResolvedValue({ auth_token: 'a' } as any);
+    jest.spyOn(AuthController.prototype, 'signOut').mockResolvedValue(true as any);
+    jest.spyOn(AuthController.prototype, 'currentUser').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(AuthController.prototype, 'resetPassword').mockResolvedValue(undefined as any);
+    jest
+      .spyOn(AuthController.prototype, 'renewAuthToken')
+      .mockResolvedValue({ auth_token: 'a', refresh_token: 'r' } as any);
+    jest
+      .spyOn(AuthController.prototype, 'sendPasswordResetEmail')
+      .mockResolvedValue(true as any);
+    caller = AuthRouter.createCaller(ctx);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('signs up', async () => {
+    await expect(
+      caller.signUp({ organization: 'Org', email: 'a@b.com', password: 'password1', first_name: 'A' }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it('signs in', async () => {
+    await expect(caller.signIn({ email: 'a@b.com', password: 'password1' })).resolves.toEqual({ auth_token: 'a' });
+  });
+
+  it('signs out', async () => {
+    await expect(caller.signOut()).resolves.toBeTruthy();
+  });
+
+  it('gets current user', async () => {
+    await expect(caller.currentUser()).resolves.toEqual({ id: '1' });
+  });
+
+  it('resets password', async () => {
+    await expect(caller.resetPassword({ password: 'newpass1', code: '123' })).resolves.toBeUndefined();
+  });
+
+  it('renews auth token', async () => {
+    await expect(caller.renewAuthToken({ auth_token: 'a', refresh_token: 'r' })).resolves.toEqual({ auth_token: 'a', refresh_token: 'r' });
+  });
+
+  it('sends password reset email', async () => {
+    await expect(caller.sendPasswordResetEmail({ email: 'a@b.com' })).resolves.toBeTruthy();
+  });
+});

--- a/apps/backend/src/app/trpc-routers/households.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/households.router.spec.ts
@@ -1,0 +1,75 @@
+import { HouseholdsController } from '../controllers/households.controller';
+import { HouseholdsRouter } from './households.router';
+
+describe('HouseholdsRouter', () => {
+  const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
+  let caller: ReturnType<typeof HouseholdsRouter.createCaller>;
+
+  beforeAll(() => {
+    jest.spyOn(HouseholdsController.prototype, 'addHousehold').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(HouseholdsController.prototype, 'attachTag').mockResolvedValue(true as any);
+    jest.spyOn(HouseholdsController.prototype, 'getCount').mockResolvedValue(1);
+    jest.spyOn(HouseholdsController.prototype, 'deleteMany').mockResolvedValue(true as any);
+    jest.spyOn(HouseholdsController.prototype, 'delete').mockResolvedValue(true as any);
+    jest.spyOn(HouseholdsController.prototype, 'detachTag').mockResolvedValue(undefined as any);
+    jest.spyOn(HouseholdsController.prototype, 'getAll').mockResolvedValue([{ id: '1' }] as any);
+    jest.spyOn(HouseholdsController.prototype, 'getAllWithPeopleCount').mockResolvedValue({ rows: [], count: 0 } as any);
+    jest.spyOn(HouseholdsController.prototype, 'getById').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(HouseholdsController.prototype, 'getDistinctTags').mockResolvedValue(['a']);
+    jest.spyOn(HouseholdsController.prototype, 'getTags').mockResolvedValue(['a']);
+    jest.spyOn(HouseholdsController.prototype, 'update').mockResolvedValue({ id: '1' } as any);
+    caller = HouseholdsRouter.createCaller(ctx);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('adds a household', async () => {
+    await expect(caller.add({} as any)).resolves.toEqual({ id: '1' });
+  });
+
+  it('attaches a tag', async () => {
+    await expect(caller.attachTag({ id: '1', tag_name: 't' })).resolves.toBeTruthy();
+  });
+
+  it('counts households', async () => {
+    await expect(caller.count()).resolves.toBe(1);
+  });
+
+  it('deletes many households', async () => {
+    await expect(caller.deleteMany(['1'])).resolves.toBeTruthy();
+  });
+
+  it('deletes a household', async () => {
+    await expect(caller.delete('1')).resolves.toBeTruthy();
+  });
+
+  it('detaches tag', async () => {
+    await expect(caller.detachTag({ id: '1', tag_name: 't' })).resolves.toBeUndefined();
+  });
+
+  it('gets all households', async () => {
+    await expect(caller.getAll()).resolves.toEqual([{ id: '1' }]);
+  });
+
+  it('gets all with people count', async () => {
+    await expect(caller.getAllWithPeopleCount({} as any)).resolves.toEqual({ rows: [], count: 0 });
+  });
+
+  it('gets household by id', async () => {
+    await expect(caller.getById('1')).resolves.toEqual({ id: '1' });
+  });
+
+  it('gets distinct tags', async () => {
+    await expect(caller.getDistinctTags()).resolves.toEqual(['a']);
+  });
+
+  it('gets tags', async () => {
+    await expect(caller.getTags('1')).resolves.toEqual(['a']);
+  });
+
+  it('updates household', async () => {
+    await expect(caller.update({ id: '1', data: {} as any })).resolves.toEqual({ id: '1' });
+  });
+});

--- a/apps/backend/src/app/trpc-routers/persons.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/persons.router.spec.ts
@@ -1,0 +1,35 @@
+import { PersonsController } from '../controllers/persons.controller';
+import { PersonsRouter } from './persons.router';
+
+describe('PersonsRouter', () => {
+  const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
+  let caller: ReturnType<typeof PersonsRouter.createCaller>;
+
+  beforeAll(() => {
+    jest.spyOn(PersonsController.prototype, 'addPerson').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(PersonsController.prototype, 'getAll').mockResolvedValue([{ id: '1' }] as any);
+    jest.spyOn(PersonsController.prototype, 'delete').mockResolvedValue(true as any);
+    jest.spyOn(PersonsController.prototype, 'getCount').mockResolvedValue(1);
+    caller = PersonsRouter.createCaller(ctx);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('adds a person', async () => {
+    await expect(caller.add({})).resolves.toEqual({ id: '1' });
+  });
+
+  it('gets all persons', async () => {
+    await expect(caller.getAll({} as any)).resolves.toEqual([{ id: '1' }]);
+  });
+
+  it('deletes a person', async () => {
+    await expect(caller.delete('1')).resolves.toBeTruthy();
+  });
+
+  it('counts persons', async () => {
+    await expect(caller.count()).resolves.toBe(1);
+  });
+});

--- a/apps/backend/src/app/trpc-routers/settings.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/settings.router.spec.ts
@@ -1,0 +1,21 @@
+import { TRPCError } from '@trpc/server';
+import { SettingsController } from '../controllers/settings.controller';
+import { SettingsRouter } from './settings.router';
+
+describe('SettingsRouter', () => {
+  const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
+  let caller: ReturnType<typeof SettingsRouter.createCaller>;
+
+  beforeAll(() => {
+    jest.spyOn(SettingsController.prototype, 'getCurrentCampaignId').mockResolvedValue(1 as any);
+    caller = SettingsRouter.createCaller(ctx);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('throws when current campaign id is not "number" string', async () => {
+    await expect(caller.getCurrentCampaignId()).rejects.toBeInstanceOf(TRPCError);
+  });
+});

--- a/apps/backend/src/app/trpc-routers/tags.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/tags.router.spec.ts
@@ -1,0 +1,60 @@
+import { TagsController } from '../controllers/tags.controller';
+import { TagsRouter } from './tags.router';
+
+describe('TagsRouter', () => {
+  const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
+  let caller: ReturnType<typeof TagsRouter.createCaller>;
+
+  beforeAll(() => {
+    jest.spyOn(TagsController.prototype, 'addTag').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(TagsController.prototype, 'getCount').mockResolvedValue(1);
+    jest.spyOn(TagsController.prototype, 'getAll').mockResolvedValue([{ id: '1' }] as any);
+    jest.spyOn(TagsController.prototype, 'updateTag').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(TagsController.prototype, 'getById').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(TagsController.prototype, 'delete').mockResolvedValue(true as any);
+    jest.spyOn(TagsController.prototype, 'deleteMany').mockResolvedValue(true as any);
+    jest.spyOn(TagsController.prototype, 'findByName').mockResolvedValue([{ id: '1' }]);
+    jest.spyOn(TagsController.prototype, 'getAllWithCounts').mockResolvedValue({ rows: [], count: 0 } as any);
+    caller = TagsRouter.createCaller(ctx);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('adds a tag', async () => {
+    await expect(caller.add({ name: 't' })).resolves.toEqual({ id: '1' });
+  });
+
+  it('counts tags', async () => {
+    await expect(caller.count()).resolves.toBe(1);
+  });
+
+  it('gets all tags', async () => {
+    await expect(caller.getAll()).resolves.toEqual([{ id: '1' }]);
+  });
+
+  it('updates a tag', async () => {
+    await expect(caller.update({ id: '1', data: { name: 'n' } })).resolves.toEqual({ id: '1' });
+  });
+
+  it('gets tag by id', async () => {
+    await expect(caller.getById('1')).resolves.toEqual({ id: '1' });
+  });
+
+  it('deletes a tag', async () => {
+    await expect(caller.delete('1')).resolves.toBeTruthy();
+  });
+
+  it('deletes many tags', async () => {
+    await expect(caller.deleteMany(['1'])).resolves.toBeTruthy();
+  });
+
+  it('finds by name', async () => {
+    await expect(caller.findByName('a')).resolves.toEqual([{ id: '1' }]);
+  });
+
+  it('gets all with counts', async () => {
+    await expect(caller.getAllWithCounts({} as any)).resolves.toEqual({ rows: [], count: 0 });
+  });
+});

--- a/jest.preset.cjs
+++ b/jest.preset.cjs
@@ -1,0 +1,2 @@
+const nxPreset = require('@nx/jest/preset').default;
+module.exports = { ...nxPreset };


### PR DESCRIPTION
## Summary
- add REST route tests for auth and households endpoints
- extend TRPC router coverage for auth, households, tags, and settings
- add TagsController and TagsRepo unit tests for tag management logic

## Testing
- `npx nx lint backend`
- `npx nx test backend --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6895425d58608321bbb90461a4d55da0