### PR TITLE
test: expand frontend coverage

### DIFF
--- a/apps/frontend/src/app/components/route-reuse-strategy.spec.ts
+++ b/apps/frontend/src/app/components/route-reuse-strategy.spec.ts
@@ -1,0 +1,27 @@
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { CustomRouteReuseStrategy } from './route-reuse-strategy';
+
+describe('CustomRouteReuseStrategy', () => {
+  let strategy: CustomRouteReuseStrategy;
+
+  beforeEach(() => {
+    strategy = new CustomRouteReuseStrategy();
+  });
+
+  it('should store and retrieve handles when reuse is enabled', () => {
+    const route = { data: { shouldReuse: true, key: 'a' } } as unknown as ActivatedRouteSnapshot;
+    const handle = {} as any;
+    expect(strategy.shouldDetach(route)).toBe(true);
+    strategy.store(route, handle);
+    expect(strategy.shouldAttach(route)).toBe(true);
+    expect(strategy.retrieve(route)).toBe(handle);
+  });
+
+  it('should not reuse routes when flag is false', () => {
+    const route = { data: { shouldReuse: false, key: 'b' } } as unknown as ActivatedRouteSnapshot;
+    expect(strategy.shouldDetach(route)).toBe(false);
+    expect(strategy.shouldAttach(route)).toBe(false);
+    expect(strategy.retrieve(route)).toBe(false);
+    expect(strategy.shouldReuseRoute(route)).toBe(false);
+  });
+});

--- a/apps/frontend/src/app/layout/theme-service.spec.ts
+++ b/apps/frontend/src/app/layout/theme-service.spec.ts
@@ -1,0 +1,27 @@
+import { ThemeService } from './theme-service';
+
+describe('ThemeService', () => {
+  const addEventListener = jest.fn();
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockReturnValue({ matches: false, addEventListener })
+    });
+    localStorage.clear();
+    addEventListener.mockReset();
+  });
+
+  it('should default to dark when system prefers dark', () => {
+    (window.matchMedia as jest.Mock).mockReturnValue({ matches: true, addEventListener });
+    const service = new ThemeService();
+    expect(service.getTheme()).toBe('dark');
+  });
+
+  it('should toggle theme and persist preference', () => {
+    const service = new ThemeService();
+    expect(service.getTheme()).toBe('light');
+    service.toggleTheme();
+    expect(service.getTheme()).toBe('dark');
+    expect(localStorage.getItem('pc-theme')).toBe('dark');
+  });
+});

--- a/apps/frontend/src/app/svg-html-pipe.spec.ts
+++ b/apps/frontend/src/app/svg-html-pipe.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { DomSanitizer } from '@angular/platform-browser';
+import { BypassHtmlSanitizerPipe } from './svg-html-pipe';
+
+describe('BypassHtmlSanitizerPipe', () => {
+  it('should use DomSanitizer to bypass html', () => {
+    const bypass = jest.fn((html: string) => `safe:${html}`);
+    TestBed.configureTestingModule({
+      providers: [{ provide: DomSanitizer, useValue: { bypassSecurityTrustHtml: bypass } }],
+    });
+
+    const pipe = TestBed.runInInjectionContext(() => new BypassHtmlSanitizerPipe());
+    const result = pipe.transform('<svg></svg>');
+
+    expect(bypass).toHaveBeenCalledWith('<svg></svg>');
+    expect(result).toBe('safe:<svg></svg>');
+  });
+});


### PR DESCRIPTION
## Summary
- add ThemeService unit tests
- test CustomRouteReuseStrategy logic
- verify bypass HTML sanitizer pipe

## Testing
- `npx nx test frontend --codeCoverage --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6896b952564883218d07e048fb6aecf5