### PR TITLE
test: add coverage for grids and services

### DIFF
--- a/apps/backend/src/app/repositories/households/households.repo.spec.ts
+++ b/apps/backend/src/app/repositories/households/households.repo.spec.ts
@@ -1,0 +1,26 @@
+import { HouseholdRepo } from './households.repo';
+
+describe('HouseholdRepo', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('getTags builds proper query', async () => {
+    const repo = new HouseholdRepo();
+    const execute = jest.fn().mockResolvedValue([]);
+    const select = jest.fn().mockReturnValue({ execute });
+    const whereTenant = jest.fn().mockReturnValue({ select });
+    const whereId = jest.fn().mockReturnValue({ where: whereTenant });
+    const innerJoinTags = jest.fn().mockReturnValue({ where: whereId });
+    const innerJoinMap = jest.fn().mockReturnValue({ innerJoin: innerJoinTags });
+    jest.spyOn(HouseholdRepo.prototype as any, 'getSelect').mockReturnValue({ innerJoin: innerJoinMap });
+
+    await repo.getTags('h1', 't1');
+
+    expect(innerJoinMap).toHaveBeenCalledWith('map_households_tags', 'map_households_tags.household_id', 'households.id');
+    expect(innerJoinTags).toHaveBeenCalledWith('tags', 'tags.id', 'map_households_tags.tag_id');
+    expect(whereId).toHaveBeenCalledWith('households.id', '=', 'h1');
+    expect(whereTenant).toHaveBeenCalledWith('households.tenant_id', '=', 't1');
+    expect(select).toHaveBeenCalledWith('tags.name');
+    expect(execute).toHaveBeenCalled();
+  });
+});
+

--- a/apps/frontend/jest.config.ts
+++ b/apps/frontend/jest.config.ts
@@ -15,7 +15,8 @@ const config: Config = {
     '^@uxcommon/(.*)$': '<rootDir>/src/app/uxcommon/$1',
     '^@services/(.*)$': '<rootDir>/src/app/services/$1',
     '^@pipes/(.*)$': '<rootDir>/src/app/pipes/$1',
-    '^@common$': '<rootDir>/../../common/src/index.ts'
+    '^@common$': '<rootDir>/../../common/src/index.ts',
+    '^apps/frontend/(.*)$': '<rootDir>/$1'
   },
   moduleFileExtensions: ['ts', 'html', 'js', 'json', 'mjs'],
   testMatch: ['<rootDir>/src/**/*.spec.ts'],

--- a/apps/frontend/src/app/features/donors/ui/donors-grid.spec.ts
+++ b/apps/frontend/src/app/features/donors/ui/donors-grid.spec.ts
@@ -1,0 +1,47 @@
+jest.mock('@uxcommon/datagrid/datagrid', () => {
+  return {
+    DataGrid: class {
+      protected router = { navigate: jest.fn() };
+      protected tagArrayEquals() {
+        return 0;
+      }
+      protected tagsToString(tags: string[]) {
+        return tags?.toString() ?? '';
+      }
+      protected openEditOnDoubleClick() {}
+    },
+  };
+});
+
+jest.mock('../../tags/ui/tags-cell-renderer', () => ({ TagsCellRenderer: class {} }), { virtual: true });
+jest.mock('@uxcommon/icon', () => ({ Icon: class {} }), { virtual: true });
+jest.mock('./donors-grid.html', () => '', { virtual: true });
+
+import { DonorsGrid } from './donors-grid';
+
+describe('DonorsGrid', () => {
+  let component: DonorsGrid;
+  let router: any;
+
+  beforeEach(() => {
+    component = new DonorsGrid();
+    router = (component as any).router;
+  });
+
+  it('should set household id and confirm on double click', () => {
+    const spy = jest.spyOn(component as any, 'confirmAddressChange').mockImplementation(() => {});
+    component['confirmOpenEditOnDoubleClick']({ data: { household_id: 'h1' } } as any);
+    expect(component['addressChangeModalId']).toBe('h1');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should navigate to households on routeToHouseholds', () => {
+    component['addressChangeModalId'] = 'h2';
+    const close = jest.fn();
+    document.querySelector = jest.fn().mockReturnValue({ close });
+    (component as any).routeToHouseholds();
+    expect(close).toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalledWith(['console', 'households', 'h2']);
+  });
+});
+

--- a/apps/frontend/src/app/features/households/services/households-service.spec.ts
+++ b/apps/frontend/src/app/features/households/services/households-service.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { HouseholdsService } from './households-service';
+import { TokenService } from 'apps/frontend/src/app/backend-svc/token-service';
+
+describe('HouseholdsService', () => {
+  let service: HouseholdsService;
+  let apiMock: any;
+
+  beforeEach(() => {
+    apiMock = {
+      households: {
+        attachTag: { mutate: jest.fn() },
+        getAllWithPeopleCount: { query: jest.fn() },
+      },
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        HouseholdsService,
+        { provide: Router, useValue: {} },
+        { provide: TokenService, useValue: { getAuthToken: () => null, getRefreshToken: () => null } },
+      ],
+    });
+    service = TestBed.inject(HouseholdsService);
+    (service as any).api = apiMock;
+  });
+
+  it('should attach tag via api', () => {
+    service.attachTag('1', 'VIP');
+    expect(apiMock.households.attachTag.mutate).toHaveBeenCalledWith({ id: '1', tag_name: 'VIP' });
+  });
+
+  it('should get all households with people count', async () => {
+    const res = { rows: [], count: 0 };
+    apiMock.households.getAllWithPeopleCount.query.mockResolvedValue(res);
+    const options = { searchStr: 'a' } as any;
+    const result = await service.getAll(options);
+    expect(apiMock.households.getAllWithPeopleCount.query).toHaveBeenCalledWith(options, { signal: service['ac'].signal });
+    expect(result).toBe(res);
+  });
+});
+

--- a/apps/frontend/src/app/features/households/ui/household-detail.spec.ts
+++ b/apps/frontend/src/app/features/households/ui/household-detail.spec.ts
@@ -1,0 +1,49 @@
+jest.mock('@uxcommon/formInput', () => ({ FormInput: class {} }), { virtual: true });
+jest.mock('@uxcommon/input', () => ({ PPlCrmInput: class {} }), { virtual: true });
+jest.mock('@uxcommon/tags/tags', () => ({ Tags: class {} }), { virtual: true });
+jest.mock('@uxcommon/textarea', () => ({ TextArea: class {} }), { virtual: true });
+jest.mock('@uxcommon/add-btn-row', () => ({ AddBtnRow: class {} }), { virtual: true });
+jest.mock('../../persons/ui/people-in-household', () => ({ PeopleInHousehold: class {} }), { virtual: true });
+jest.mock('./household-detail.html', () => '', { virtual: true });
+
+import { TestBed } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { HouseholdDetail } from './household-detail';
+import { AlertService } from '@uxcommon/alerts/alert-service';
+import { HouseholdsService } from '../services/households-service';
+import { PersonsService } from '../../persons/services/persons-service';
+
+describe('HouseholdDetail', () => {
+  let component: HouseholdDetail;
+  let alertSvc: AlertService;
+  let householdsSvc: HouseholdsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AlertService, useValue: { showError: jest.fn(), showSuccess: jest.fn() } },
+        { provide: HouseholdsService, useValue: { attachTag: jest.fn(), detachTag: jest.fn() } },
+        { provide: PersonsService, useValue: { getPeopleInHousehold: jest.fn() } },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => null } } } },
+        { provide: FormBuilder, useValue: new FormBuilder() },
+      ],
+    });
+    alertSvc = TestBed.inject(AlertService);
+    householdsSvc = TestBed.inject(HouseholdsService);
+    component = TestBed.runInInjectionContext(() => new HouseholdDetail());
+  });
+
+  it('should show error when address lacks components', () => {
+    component.handleAddressChange({} as any);
+    expect(alertSvc.showError).toHaveBeenCalled();
+    expect(component['addressVerified']).toBe(false);
+  });
+
+  it('should attach tag when tag added', () => {
+    component['id'] = 'h1';
+    (component as any).tagAdded('vip');
+    expect(householdsSvc.attachTag).toHaveBeenCalledWith('h1', 'vip');
+  });
+});
+

--- a/apps/frontend/src/app/features/households/ui/households-grid.spec.ts
+++ b/apps/frontend/src/app/features/households/ui/households-grid.spec.ts
@@ -1,0 +1,31 @@
+jest.mock('@uxcommon/datagrid/datagrid', () => {
+  return {
+    DataGrid: class {
+      protected tagArrayEquals() {
+        return 0;
+      }
+      protected tagsToString(tags: string[]) {
+        return tags?.toString() ?? '';
+      }
+      protected openEditOnDoubleClick() {}
+    },
+  };
+});
+
+jest.mock('../../tags/ui/tags-cell-renderer', () => ({ TagsCellRenderer: class {} }), { virtual: true });
+
+import { HouseholdsGrid } from './households-grid';
+
+describe('HouseholdsGrid', () => {
+  let component: HouseholdsGrid;
+
+  beforeEach(() => {
+    component = new HouseholdsGrid();
+  });
+
+  it('should define persons_count column', () => {
+    const hasPersonsCount = component['col'].some((c) => c.field === 'persons_count');
+    expect(hasPersonsCount).toBe(true);
+  });
+});
+

--- a/apps/frontend/src/app/features/tags/ui/tags-cell-renderer.spec.ts
+++ b/apps/frontend/src/app/features/tags/ui/tags-cell-renderer.spec.ts
@@ -1,0 +1,31 @@
+import { TagsCellRenderer } from './tags-cell-renderer';
+
+jest.mock('@uxcommon/tags/tags', () => ({ Tags: class {} }), { virtual: true });
+
+describe('TagsCellRenderer', () => {
+  it('should remove tag using service and update grid', () => {
+    const renderer = new TagsCellRenderer();
+    const detachTag = jest.fn();
+    const setDataValue = jest.fn();
+    const api = { getRowNode: jest.fn().mockReturnValue({ setDataValue }) } as any;
+    renderer.agInit({
+      value: ['a', 'b'],
+      api,
+      service: { detachTag } as any,
+      data: { id: '1' },
+      colDef: { field: 'tags' },
+    } as any);
+    renderer['tags'] = ['b'];
+    renderer.removeTag('a');
+    expect(detachTag).toHaveBeenCalledWith('1', 'a');
+    expect(setDataValue).toHaveBeenCalledWith('tags', ['b']);
+  });
+
+  it('should refresh tags', () => {
+    const renderer = new TagsCellRenderer();
+    renderer.agInit({ value: ['a'], api: {} as any, data: { id: '1' }, colDef: { field: 'tags' } } as any);
+    renderer.refresh({ value: ['c'] } as any);
+    expect((renderer as any).tags).toEqual(['c']);
+  });
+});
+

--- a/apps/frontend/src/app/uxcommon/alerts/alert-service.spec.ts
+++ b/apps/frontend/src/app/uxcommon/alerts/alert-service.spec.ts
@@ -1,0 +1,35 @@
+import { AlertService } from './alert-service';
+
+describe('AlertService', () => {
+  let service: AlertService;
+
+  beforeEach(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: { randomUUID: () => 'id-1' },
+      writable: true,
+    });
+    service = new AlertService();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should show and dismiss alert', () => {
+    service.show({ text: 'hi', type: 'info' });
+    const id = service.getAlerts()[0].id;
+    service.dismiss(id);
+    jest.runAllTimers();
+    expect(service.getAlerts()).toHaveLength(0);
+  });
+
+  it('should call OK button callback', () => {
+    const callback = jest.fn();
+    service.show({ text: 'x', type: 'success', OKBtnCallback: callback });
+    const id = service.getAlerts()[0].id;
+    service.OKBtnCallback(id);
+    expect(callback).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for donor and household grids and services
- test alert service behaviors and tags cell renderer
- verify household repository query builder on backend

## Testing
- `CI=true npx nx test frontend --runInBand`
- `CI=true npx nx test backend --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68975427b14c8321aba3bf15e02eafa2