### PR TITLE
refactor: replace deprecated setup-jest

### DIFF
--- a/apps/frontend/jest.config.ts
+++ b/apps/frontend/jest.config.ts
@@ -2,7 +2,6 @@ import type { Config } from 'jest';
 
 const config: Config = {
   preset: 'jest-preset-angular',
-  globalSetup: 'jest-preset-angular/global-setup',
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   transform: {
     '^.+\\.(ts|mjs|js|html)$': [

--- a/apps/frontend/src/test-setup.ts
+++ b/apps/frontend/src/test-setup.ts
@@ -1,8 +1,6 @@
-// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
-globalThis.ngJest = {
-  testEnvironmentOptions: {
-    errorOnUnknownElements: true,
-    errorOnUnknownProperties: true,
-  },
-};
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv({
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
+});


### PR DESCRIPTION
## Summary
- use setupZoneTestEnv instead of deprecated setup-jest
- drop unused jest-preset-angular global setup

## Testing
- `CI=1 npx nx lint frontend`
- `CI=1 npx nx test frontend`


------
https://chatgpt.com/codex/tasks/task_e_689757fe45dc832193b9cf6faae3398d