### PR TITLE
Filter donors grid by donor tag

### DIFF
--- a/apps/frontend/src/app/features/donors/ui/donors-grid.html
+++ b/apps/frontend/src/app/features/donors/ui/donors-grid.html
@@ -3,7 +3,7 @@
   [disableDelete]="false"
   addRoute="add"
   [disableView]="false"
-  [limitToTags]="['Donor']"
+  [limitToTags]="['donor']"
   plusIcon="user-plus"
 ></pc-datagrid>
 

--- a/apps/frontend/src/app/uxcommon/datagrid/datagrid.ts
+++ b/apps/frontend/src/app/uxcommon/datagrid/datagrid.ts
@@ -109,6 +109,7 @@ export class DataGrid<T extends keyof Models, U> implements OnInit {
             endRow: (startRow || 0) + 10, // TODO: page size
             sortModel,
             filterModel,
+            tags: this.limitToTags(),
           } as getAllOptionsType;
 
           const data = await this.gridSvc.getAll(options);


### PR DESCRIPTION
## Summary
- Ensure server-side grid requests honor tag filters so donor view only loads tagged persons
- Configure donors grid to request people tagged 'donor'

## Testing
- `npx nx test frontend` *(failed: terminal emulator crashed before completing)*

------
https://chatgpt.com/codex/tasks/task_e_689758863de08321afb7a8540b6fddfe