### PR TITLE
fix: refresh grid data

### DIFF
--- a/apps/frontend/src/app/uxcommon/datagrid/datagrid.ts
+++ b/apps/frontend/src/app/uxcommon/datagrid/datagrid.ts
@@ -283,15 +283,17 @@ export class DataGrid<T extends keyof Models, U> implements OnInit {
   /** Triggers a full grid refresh via backend. */
   protected async refresh(): Promise<void> {
     try {
-      this.api?.setGridOption('loading', true);
-
       if (this.rowModelType() === 'clientSide') {
+        this.api?.setGridOption('loading', true);
         const rowData = await this.gridSvc.getAll({ tags: this.limitToTags() });
         this.api?.setGridOption('rowData', rowData.rows as Partial<T>[]);
+        this.api?.setGridOption('loading', false);
+      } else {
+        this.api?.setGridOption('loading', true);
+        this.api?.refreshServerSide({ purge: true });
       }
     } catch (error) {
       this.alertSvc.showError('Could not load the data. Please try again later.');
-    } finally {
       this.api?.setGridOption('loading', false);
     }
   }


### PR DESCRIPTION
## Summary
- ensure datagrid refresh reloads rows for client and server row models

## Testing
- `npx nx test frontend`

------
https://chatgpt.com/codex/tasks/task_e_68978117bee08321985498adafdbea60