### PR TITLE
feat: add basic email client

### DIFF
--- a/apps/backend/src/app/_migrations/2023-12-03-setup.ts
+++ b/apps/backend/src/app/_migrations/2023-12-03-setup.ts
@@ -16,6 +16,9 @@ export async function down(db: Kysely<any>): Promise<void> {
   await db.schema.dropTable('tags').cascade().execute();
   await db.schema.dropTable('map_peoples_tags').cascade().execute();
   await db.schema.dropTable('map_households_tags').cascade().execute();
+  await db.schema.dropTable('email_comments').cascade().execute();
+  await db.schema.dropTable('emails').cascade().execute();
+  await db.schema.dropTable('email_folders').cascade().execute();
   await db.schema.dropTable('settings').cascade().execute();
 }
 
@@ -524,6 +527,177 @@ export async function up(db: Kysely<any>): Promise<void> {
         email: 'sara.jones@email.com',
       },
     ])
+    .execute();
+
+  await db.schema
+    .createTable('email_folders')
+    .addColumn('id', 'bigserial', (col) => col.primaryKey().unique())
+    .addColumn('tenant_id', 'bigint', (col) => col.notNull())
+    .addColumn('name', 'text', (col) => col.notNull())
+    .addColumn('createdby_id', 'bigint', (col) => col.notNull())
+    .addColumn('updatedby_id', 'bigint', (col) => col.notNull())
+    .addColumn('created_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addColumn('updated_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .execute();
+
+  await db.schema
+    .createTable('emails')
+    .addColumn('id', 'bigserial', (col) => col.primaryKey().unique())
+    .addColumn('tenant_id', 'bigint', (col) => col.notNull())
+    .addColumn('folder_id', 'bigint', (col) => col.notNull())
+    .addColumn('from_email', 'text')
+    .addColumn('to_email', 'text')
+    .addColumn('subject', 'text')
+    .addColumn('body', 'text')
+    .addColumn('assigned_to', 'bigint')
+    .addColumn('createdby_id', 'bigint', (col) => col.notNull())
+    .addColumn('updatedby_id', 'bigint', (col) => col.notNull())
+    .addColumn('created_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addColumn('updated_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addForeignKeyConstraint('fk_emails_folder', ['folder_id'], 'email_folders', ['id'])
+    .addForeignKeyConstraint('fk_emails_assigned', ['assigned_to'], 'authusers', ['id'])
+    .execute();
+
+  await db.schema
+    .createTable('email_comments')
+    .addColumn('id', 'bigserial', (col) => col.primaryKey().unique())
+    .addColumn('tenant_id', 'bigint', (col) => col.notNull())
+    .addColumn('email_id', 'bigint', (col) => col.notNull())
+    .addColumn('author_id', 'bigint', (col) => col.notNull())
+    .addColumn('comment', 'text', (col) => col.notNull())
+    .addColumn('createdby_id', 'bigint', (col) => col.notNull())
+    .addColumn('updatedby_id', 'bigint', (col) => col.notNull())
+    .addColumn('created_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addColumn('updated_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addForeignKeyConstraint('fk_email_comments_email', ['email_id'], 'emails', ['id'])
+    .addForeignKeyConstraint('fk_email_comments_author', ['author_id'], 'authusers', ['id'])
+    .execute();
+
+  await db
+    .insertInto('email_folders')
+    .values([
+      { id: 1, tenant_id: 1, name: 'Inbox', createdby_id: 1, updatedby_id: 1 },
+      { id: 2, tenant_id: 1, name: 'Sent', createdby_id: 1, updatedby_id: 1 },
+    ])
+    .execute();
+
+  await db
+    .insertInto('emails')
+    .values([
+      {
+        tenant_id: 1,
+        folder_id: 1,
+        createdby_id: 1,
+        updatedby_id: 1,
+        from_email: 'alice@example.com',
+        to_email: 'user@example.com',
+        subject: 'Welcome',
+        body: 'Welcome to the system!',
+        assigned_to: 1,
+      },
+      {
+        tenant_id: 1,
+        folder_id: 1,
+        createdby_id: 1,
+        updatedby_id: 1,
+        from_email: 'bob@example.com',
+        to_email: 'user@example.com',
+        subject: 'Meeting',
+        body: 'Can we meet tomorrow?',
+      },
+      {
+        tenant_id: 1,
+        folder_id: 1,
+        createdby_id: 1,
+        updatedby_id: 1,
+        from_email: 'carol@example.com',
+        to_email: 'user@example.com',
+        subject: 'Invoice',
+        body: 'Please find attached invoice.',
+      },
+      {
+        tenant_id: 1,
+        folder_id: 1,
+        createdby_id: 1,
+        updatedby_id: 1,
+        from_email: 'dave@example.com',
+        to_email: 'user@example.com',
+        subject: 'Question',
+        body: 'I have a question.',
+      },
+      {
+        tenant_id: 1,
+        folder_id: 1,
+        createdby_id: 1,
+        updatedby_id: 1,
+        from_email: 'erin@example.com',
+        to_email: 'user@example.com',
+        subject: 'Feedback',
+        body: 'Here is some feedback.',
+      },
+      {
+        tenant_id: 1,
+        folder_id: 1,
+        createdby_id: 1,
+        updatedby_id: 1,
+        from_email: 'frank@example.com',
+        to_email: 'user@example.com',
+        subject: 'Greetings',
+        body: 'Greetings and best wishes.',
+      },
+      {
+        tenant_id: 1,
+        folder_id: 1,
+        createdby_id: 1,
+        updatedby_id: 1,
+        from_email: 'gina@example.com',
+        to_email: 'user@example.com',
+        subject: 'Update',
+        body: 'Here is an update.',
+      },
+      {
+        tenant_id: 1,
+        folder_id: 1,
+        createdby_id: 1,
+        updatedby_id: 1,
+        from_email: 'harry@example.com',
+        to_email: 'user@example.com',
+        subject: 'Reminder',
+        body: 'This is a reminder.',
+      },
+      {
+        tenant_id: 1,
+        folder_id: 1,
+        createdby_id: 1,
+        updatedby_id: 1,
+        from_email: 'ivy@example.com',
+        to_email: 'user@example.com',
+        subject: 'Invitation',
+        body: 'You are invited.',
+      },
+      {
+        tenant_id: 1,
+        folder_id: 1,
+        createdby_id: 1,
+        updatedby_id: 1,
+        from_email: 'jack@example.com',
+        to_email: 'user@example.com',
+        subject: 'Thanks',
+        body: 'Thank you!',
+      },
+    ])
+    .execute();
+
+  await db
+    .insertInto('email_comments')
+    .values({
+      tenant_id: 1,
+      email_id: 1,
+      author_id: 1,
+      comment: 'First comment',
+      createdby_id: 1,
+      updatedby_id: 1,
+    })
     .execute();
 
   await db.schema

--- a/apps/backend/src/app/controllers/emails.controller.ts
+++ b/apps/backend/src/app/controllers/emails.controller.ts
@@ -1,0 +1,50 @@
+import { BaseController } from './base.controller';
+import { EmailRepo } from '../repositories/emails/email.repo';
+import { EmailCommentsRepo } from '../repositories/emails/email-comments.repo';
+import { EmailFoldersRepo } from '../repositories/emails/email-folders.repo';
+
+/** Controller handling email operations */
+export class EmailsController extends BaseController<'emails', EmailRepo> {
+  private commentsRepo = new EmailCommentsRepo();
+  private foldersRepo = new EmailFoldersRepo();
+
+  constructor() {
+    super(new EmailRepo());
+  }
+
+  /** Return all folders for a tenant */
+  public getFolders(tenant_id: string) {
+    return this.foldersRepo.getAll({ tenant_id: tenant_id as any });
+  }
+
+  /** Return all emails for the given folder */
+  public getEmails(tenant_id: string, folder_id: string) {
+    return this.getRepo().getByFolder(tenant_id, folder_id);
+  }
+
+  /** Return a single email and its comments */
+  public async getEmail(tenant_id: string, id: string) {
+    const email = await this.getById({ tenant_id, id });
+    const comments = await this.commentsRepo.getForEmail(tenant_id, id);
+    return { email, comments };
+  }
+
+  /** Add a comment to an email */
+  public addComment(tenant_id: string, email_id: string, author_id: string, comment: string) {
+    return this.commentsRepo.add({
+      row: {
+        tenant_id,
+        email_id,
+        author_id,
+        comment,
+        createdby_id: author_id,
+        updatedby_id: author_id,
+      },
+    });
+  }
+
+  /** Assign an email to a user */
+  public assignEmail(tenant_id: string, id: string, user_id: string) {
+    return this.update({ tenant_id, id, row: { assigned_to: user_id } });
+  }
+}

--- a/apps/backend/src/app/repositories/emails/email-comments.repo.ts
+++ b/apps/backend/src/app/repositories/emails/email-comments.repo.ts
@@ -1,0 +1,17 @@
+import { BaseRepository } from '../base.repo';
+
+/** Repository for email comments */
+export class EmailCommentsRepo extends BaseRepository<'email_comments'> {
+  constructor() {
+    super('email_comments');
+  }
+
+  /** Retrieve comments for a specific email */
+  public getForEmail(tenant_id: string, email_id: string) {
+    return this.getSelect()
+      .selectAll()
+      .where('tenant_id', '=', tenant_id)
+      .where('email_id', '=', email_id)
+      .execute();
+  }
+}

--- a/apps/backend/src/app/repositories/emails/email-folders.repo.ts
+++ b/apps/backend/src/app/repositories/emails/email-folders.repo.ts
@@ -1,0 +1,8 @@
+import { BaseRepository } from '../base.repo';
+
+/** Repository for email folders */
+export class EmailFoldersRepo extends BaseRepository<'email_folders'> {
+  constructor() {
+    super('email_folders');
+  }
+}

--- a/apps/backend/src/app/repositories/emails/email.repo.ts
+++ b/apps/backend/src/app/repositories/emails/email.repo.ts
@@ -1,0 +1,17 @@
+import { BaseRepository } from '../base.repo';
+
+/** Repository for email records */
+export class EmailRepo extends BaseRepository<'emails'> {
+  constructor() {
+    super('emails');
+  }
+
+  /** Get all emails within a folder for a tenant */
+  public getByFolder(tenant_id: string, folder_id: string) {
+    return this.getSelect()
+      .selectAll()
+      .where('tenant_id', '=', tenant_id)
+      .where('folder_id', '=', folder_id)
+      .execute();
+  }
+}

--- a/apps/backend/src/app/routes.ts
+++ b/apps/backend/src/app/routes.ts
@@ -3,6 +3,7 @@ import { FastifyPluginCallback } from 'fastify';
 import authRoute from './routes/auth/auth.route';
 import householdsRoute from './routes/households/households.route';
 import personsRoute from './routes/persons/persons.route';
+import emailsRoute from './routes/emails/emails.route';
 
 /**
  * Registers all REST API routes for the application.
@@ -20,9 +21,12 @@ export const routes: FastifyPluginCallback = (fastify, _opts, done) => {
 
   // Register versioned /v1/households route module
   fastify.register(householdsRoute, { prefix: '/v1/households' });
-
+  
   // Register authentication routes under /auth
   fastify.register(authRoute, { prefix: '/auth/' });
+
+  // Register email routes
+  fastify.register(emailsRoute, { prefix: '/v1/emails' });
 
   // Root health check endpoint
   fastify.get('/', (_req, res) => res.send({ message: 'API healthy.' }));

--- a/apps/backend/src/app/routes/emails/emails.route.spec.ts
+++ b/apps/backend/src/app/routes/emails/emails.route.spec.ts
@@ -1,0 +1,38 @@
+import Fastify from 'fastify';
+import { EmailsController } from '../../controllers/emails.controller';
+
+describe('emails REST routes', () => {
+  const tenantId = 'tenant-1';
+  let app: ReturnType<typeof Fastify>;
+  const folders = [{ id: '1', name: 'Inbox' }];
+  const emails = [{ id: '10', subject: 'Test' }];
+
+  beforeAll(async () => {
+    jest.spyOn(EmailsController.prototype, 'getFolders').mockResolvedValue(folders as any);
+    jest
+      .spyOn(EmailsController.prototype, 'getEmails')
+      .mockImplementation(async (_t, folder) => (folder === '1' ? emails : []) as any);
+
+    const routes = (await import('./emails.route')).default;
+    app = Fastify();
+    app.register(routes, { prefix: '/emails' });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    await app.close();
+  });
+
+  it('gets folders', async () => {
+    const res = await app.inject({ method: 'GET', url: '/emails/folders', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(folders);
+  });
+
+  it('gets emails in folder', async () => {
+    const res = await app.inject({ method: 'GET', url: '/emails/folder/1', headers: { 'tenant-id': tenantId } });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(emails);
+  });
+});

--- a/apps/backend/src/app/routes/emails/emails.route.ts
+++ b/apps/backend/src/app/routes/emails/emails.route.ts
@@ -1,0 +1,28 @@
+import { FastifyPluginCallback, FastifyRequest } from 'fastify';
+import { EmailsController } from '../../controllers/emails.controller';
+import { IdParam } from '../fastify.types';
+
+const emails = new EmailsController();
+
+/** REST routes for email operations */
+const routes: FastifyPluginCallback = (fastify, _, done) => {
+  fastify.get('/folders', (req: FastifyRequest) => emails.getFolders(req.headers['tenant-id'] as string));
+  fastify.get('/folder/:folderId', (req: FastifyRequest) =>
+    emails.getEmails(req.headers['tenant-id'] as string, (req.params as any).folderId),
+  );
+  fastify.get('/message/:id', (req: IdParam) => emails.getEmail(req.headers['tenant-id'] as string, req.params.id));
+  fastify.post('/message/:id/comment', (req: FastifyRequest<{ Body: { author_id: string; comment: string } }> ) =>
+    emails.addComment(
+      req.headers['tenant-id'] as string,
+      (req.params as any).id,
+      req.body.author_id,
+      req.body.comment,
+    ),
+  );
+  fastify.post('/message/:id/assign', (req: FastifyRequest<{ Body: { user_id: string } }> ) =>
+    emails.assignEmail(req.headers['tenant-id'] as string, (req.params as any).id, req.body.user_id),
+  );
+  done();
+};
+
+export default routes;

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { HouseholdsGrid } from './features/households/ui/households-grid';
 import { PersonDetail } from './features/persons/ui/person-detail';
 import { PersonsGrid } from './features/persons/ui/persons-grid';
 import { TagsGridComponent } from './features/tags/ui/tags-grid';
+import { EmailClient } from './features/emails/ui/email-client';
 import { Dashboard } from './layout/dashboards/dashboard';
 import { Summary } from './temp/summary';
 
@@ -144,6 +145,11 @@ export const appRoutes: Route[] = [
             data: { shouldReuse: true, key: 'donorsgridroot', tags: ['donor'] },
           },
         ],
+      },
+
+      {
+        path: 'emails',
+        component: EmailClient,
       },
     ],
   },

--- a/apps/frontend/src/app/features/emails/services/emails-service.ts
+++ b/apps/frontend/src/app/features/emails/services/emails-service.ts
@@ -1,0 +1,33 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../environments/environment';
+
+interface Folder { id: string; name: string }
+interface Email { id: string; subject: string; body: string }
+
+/** Service for interacting with email backend */
+@Injectable({ providedIn: 'root' })
+export class EmailsService {
+  private http = inject(HttpClient);
+  private base = `${environment.apiUrl}/v1/emails`;
+
+  getFolders() {
+    return this.http.get<Folder[]>(`${this.base}/folders`);
+  }
+
+  getEmails(folderId: string) {
+    return this.http.get<Email[]>(`${this.base}/folder/${folderId}`);
+  }
+
+  getEmail(id: string) {
+    return this.http.get<{ email: Email; comments: any[] }>(`${this.base}/message/${id}`);
+  }
+
+  addComment(id: string, author_id: string, comment: string) {
+    return this.http.post(`${this.base}/message/${id}/comment`, { author_id, comment });
+  }
+
+  assign(id: string, user_id: string) {
+    return this.http.post(`${this.base}/message/${id}/assign`, { user_id });
+  }
+}

--- a/apps/frontend/src/app/features/emails/ui/email-client.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client.spec.ts
@@ -1,0 +1,32 @@
+import { of } from 'rxjs';
+import { EmailClient } from './email-client';
+import { EmailsService } from '../services/emails-service';
+
+jest.mock('../services/emails-service', () => ({
+  EmailsService: class {
+    getFolders() {
+      return of([{ id: '1', name: 'Inbox' }]);
+    }
+    getEmails() {
+      return of([]);
+    }
+    getEmail() {
+      return of({ email: { id: '1', subject: 'a', body: 'b' }, comments: [] });
+    }
+    addComment() {
+      return of(null);
+    }
+    assign() {
+      return of(null);
+    }
+  },
+}));
+
+describe('EmailClient', () => {
+  it('loads folders on init', () => {
+    const svc = new EmailsService();
+    const comp = new EmailClient(svc as any);
+    comp.ngOnInit();
+    expect(comp.folders.length).toBe(1);
+  });
+});

--- a/apps/frontend/src/app/features/emails/ui/email-client.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client.ts
@@ -1,0 +1,82 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { EmailsService } from '../services/emails-service';
+
+@Component({
+  selector: 'pc-email-client',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="flex gap-4">
+      <div class="w-1/5">
+        <ul>
+          <li *ngFor="let f of folders" (click)="selectFolder(f)">{{ f.name }}</li>
+        </ul>
+      </div>
+      <div class="w-1/5">
+        <ul>
+          <li *ngFor="let e of emails" (click)="selectEmail(e)">{{ e.subject }}</li>
+        </ul>
+      </div>
+      <div class="flex-1" *ngIf="selectedEmail">
+        <h3>{{ selectedEmail.subject }}</h3>
+        <p>{{ selectedEmail.body }}</p>
+        <div>
+          <div *ngFor="let c of comments">{{ c.comment }}</div>
+          <textarea [(ngModel)]="newComment"></textarea>
+          <button (click)="addComment()">Add Comment</button>
+        </div>
+        <div class="mt-2">
+          <input [(ngModel)]="assignTo" placeholder="Assign to user id" />
+          <button (click)="assign()">Assign</button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class EmailClient implements OnInit {
+  folders: any[] = [];
+  emails: any[] = [];
+  comments: any[] = [];
+  selectedEmail: any | null = null;
+  newComment = '';
+  assignTo = '';
+
+  constructor(private svc: EmailsService) {}
+
+  ngOnInit() {
+    this.svc.getFolders().subscribe((f) => (this.folders = f));
+  }
+
+  selectFolder(folder: any) {
+    this.svc.getEmails(folder.id).subscribe((e) => {
+      this.emails = e;
+      this.selectedEmail = null;
+      this.comments = [];
+    });
+  }
+
+  selectEmail(email: any) {
+    this.svc.getEmail(email.id).subscribe((res) => {
+      this.selectedEmail = res.email;
+      this.comments = res.comments;
+    });
+  }
+
+  addComment() {
+    if (!this.selectedEmail || !this.newComment) return;
+    this.svc.addComment(this.selectedEmail.id, '1', this.newComment).subscribe(() => {
+      this.comments.push({ comment: this.newComment });
+      this.newComment = '';
+    });
+  }
+
+  assign() {
+    if (!this.selectedEmail || !this.assignTo) return;
+    this.svc.assign(this.selectedEmail.id, this.assignTo).subscribe(() => {
+      this.selectedEmail.assigned_to = this.assignTo;
+      this.assignTo = '';
+    });
+  }
+}

--- a/common/src/lib/kysely.models.ts
+++ b/common/src/lib/kysely.models.ts
@@ -41,6 +41,9 @@ export interface Models {
   tags: Tags;
   tenants: Tenants;
   settings: Settings;
+  email_folders: EmailFolders;
+  emails: Emails;
+  email_comments: EmailComments;
 }
 
 export type AuthUsersType = Omit<AuthUsers, 'id'> & { id: string };
@@ -250,6 +253,25 @@ interface Tenants extends RecordType, AddressType {
   phone: string | null;
   json: Json | null;
   notes: string | null;
+}
+
+interface EmailFolders extends RecordType {
+  name: string;
+}
+
+interface Emails extends RecordType {
+  folder_id: string;
+  from_email: string | null;
+  to_email: string | null;
+  subject: string | null;
+  body: string | null;
+  assigned_to: string | null;
+}
+
+interface EmailComments extends RecordType {
+  email_id: string;
+  author_id: string;
+  comment: string;
 }
 
 /** Take the “S” (select-time) part if it’s a ColumnType, otherwise leave as-is */


### PR DESCRIPTION
## Summary
- scaffold email client component with folder list, message preview, comments and assignment
- create backend endpoints and schema for emails, comments and folders
- seed initial folders and ten sample emails in migration

## Testing
- `npx nx test backend --runInBand`
- `npx jest -c apps/frontend/jest.config.ts apps/frontend/src/app/features/emails/ui/email-client.spec.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_689782d8e0508321bb7f3c8477d68d1e