### PR TITLE
feat: migrate email service to trpc

### DIFF
--- a/apps/backend/src/app/trpc-routers/emails.router.ts
+++ b/apps/backend/src/app/trpc-routers/emails.router.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+import { authProcedure, router } from '../../trpc';
+import { EmailsController } from '../controllers/emails.controller';
+
+const emails = new EmailsController();
+
+function getFolders() {
+  return authProcedure.query(({ ctx }) => emails.getFolders(ctx.auth.tenant_id));
+}
+
+function getEmails() {
+  return authProcedure
+    .input(z.object({ folderId: z.string() }))
+    .query(({ input, ctx }) => emails.getEmails(ctx.auth.tenant_id, input.folderId));
+}
+
+function getEmail() {
+  return authProcedure.input(z.string()).query(({ input, ctx }) => emails.getEmail(ctx.auth.tenant_id, input));
+}
+
+function addComment() {
+  return authProcedure
+    .input(z.object({ id: z.string(), author_id: z.string(), comment: z.string() }))
+    .mutation(({ input, ctx }) => emails.addComment(ctx.auth.tenant_id, input.id, input.author_id, input.comment));
+}
+
+function assign() {
+  return authProcedure
+    .input(z.object({ id: z.string(), user_id: z.string() }))
+    .mutation(({ input, ctx }) => emails.assignEmail(ctx.auth.tenant_id, input.id, input.user_id));
+}
+
+/**
+ * Emails endpoints
+ */
+export const EmailsRouter = router({
+  getFolders: getFolders(),
+  getEmails: getEmails(),
+  getEmail: getEmail(),
+  addComment: addComment(),
+  assign: assign(),
+});

--- a/apps/backend/src/app/trpc-routers/index.ts
+++ b/apps/backend/src/app/trpc-routers/index.ts
@@ -4,6 +4,7 @@ import { HouseholdsRouter } from './households.router';
 import { PersonsRouter } from './persons.router';
 import { TagsRouter } from './tags.router';
 import { UserProfilesRouter } from './userprofiles.router';
+import { EmailsRouter } from './emails.router';
 
 /**
  * Registers and groups all tRPC routers for the application.
@@ -21,6 +22,7 @@ export const trpcRouter = router({
   households: HouseholdsRouter,
   persons: PersonsRouter,
   tags: TagsRouter,
+  emails: EmailsRouter,
 });
 
 /**
@@ -34,3 +36,4 @@ export { HouseholdsRouter } from './households.router';
 export { PersonsRouter } from './persons.router';
 export { TagsRouter } from './tags.router';
 export { UserProfilesRouter } from './userprofiles.router';
+export { EmailsRouter } from './emails.router';

--- a/apps/frontend/src/app/features/emails/services/emails-service.ts
+++ b/apps/frontend/src/app/features/emails/services/emails-service.ts
@@ -1,33 +1,27 @@
-import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { environment } from '../../../../environments/environment';
+import { Injectable } from '@angular/core';
 
-interface Folder { id: string; name: string }
-interface Email { id: string; subject: string; body: string }
+import { TRPCService } from '../../../backend-svc/trpc-service';
 
-/** Service for interacting with email backend */
+/** Service for interacting with email backend via tRPC */
 @Injectable({ providedIn: 'root' })
-export class EmailsService {
-  private http = inject(HttpClient);
-  private base = `${environment.apiUrl}/v1/emails`;
-
+export class EmailsService extends TRPCService<'emails'> {
   getFolders() {
-    return this.http.get<Folder[]>(`${this.base}/folders`);
+    return this.api.emails.getFolders.query();
   }
 
   getEmails(folderId: string) {
-    return this.http.get<Email[]>(`${this.base}/folder/${folderId}`);
+    return this.api.emails.getEmails.query({ folderId });
   }
 
   getEmail(id: string) {
-    return this.http.get<{ email: Email; comments: any[] }>(`${this.base}/message/${id}`);
+    return this.api.emails.getEmail.query(id);
   }
 
   addComment(id: string, author_id: string, comment: string) {
-    return this.http.post(`${this.base}/message/${id}/comment`, { author_id, comment });
+    return this.api.emails.addComment.mutate({ id, author_id, comment });
   }
 
   assign(id: string, user_id: string) {
-    return this.http.post(`${this.base}/message/${id}/assign`, { user_id });
+    return this.api.emails.assign.mutate({ id, user_id });
   }
 }

--- a/apps/frontend/src/app/features/emails/ui/email-client.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client.spec.ts
@@ -1,32 +1,31 @@
-import { of } from 'rxjs';
 import { EmailClient } from './email-client';
 import { EmailsService } from '../services/emails-service';
 
 jest.mock('../services/emails-service', () => ({
   EmailsService: class {
     getFolders() {
-      return of([{ id: '1', name: 'Inbox' }]);
+      return Promise.resolve([{ id: '1', name: 'Inbox' }]);
     }
     getEmails() {
-      return of([]);
+      return Promise.resolve([]);
     }
     getEmail() {
-      return of({ email: { id: '1', subject: 'a', body: 'b' }, comments: [] });
+      return Promise.resolve({ email: { id: '1', subject: 'a', body: 'b' }, comments: [] });
     }
     addComment() {
-      return of(null);
+      return Promise.resolve(null);
     }
     assign() {
-      return of(null);
+      return Promise.resolve(null);
     }
   },
 }));
 
 describe('EmailClient', () => {
-  it('loads folders on init', () => {
+  it('loads folders on init', async () => {
     const svc = new EmailsService();
     const comp = new EmailClient(svc as any);
-    comp.ngOnInit();
+    await comp.ngOnInit();
     expect(comp.folders.length).toBe(1);
   });
 });

--- a/apps/frontend/src/app/features/emails/ui/email-client.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client.ts
@@ -45,38 +45,34 @@ export class EmailClient implements OnInit {
 
   constructor(private svc: EmailsService) {}
 
-  ngOnInit() {
-    this.svc.getFolders().subscribe((f) => (this.folders = f));
+  async ngOnInit() {
+    this.folders = await this.svc.getFolders();
   }
 
-  selectFolder(folder: any) {
-    this.svc.getEmails(folder.id).subscribe((e) => {
-      this.emails = e;
-      this.selectedEmail = null;
-      this.comments = [];
-    });
+  async selectFolder(folder: any) {
+    const e = await this.svc.getEmails(folder.id);
+    this.emails = e;
+    this.selectedEmail = null;
+    this.comments = [];
   }
 
-  selectEmail(email: any) {
-    this.svc.getEmail(email.id).subscribe((res) => {
-      this.selectedEmail = res.email;
-      this.comments = res.comments;
-    });
+  async selectEmail(email: any) {
+    const res = await this.svc.getEmail(email.id);
+    this.selectedEmail = res.email;
+    this.comments = res.comments;
   }
 
-  addComment() {
+  async addComment() {
     if (!this.selectedEmail || !this.newComment) return;
-    this.svc.addComment(this.selectedEmail.id, '1', this.newComment).subscribe(() => {
-      this.comments.push({ comment: this.newComment });
-      this.newComment = '';
-    });
+    await this.svc.addComment(this.selectedEmail.id, '1', this.newComment);
+    this.comments.push({ comment: this.newComment });
+    this.newComment = '';
   }
 
-  assign() {
+  async assign() {
     if (!this.selectedEmail || !this.assignTo) return;
-    this.svc.assign(this.selectedEmail.id, this.assignTo).subscribe(() => {
-      this.selectedEmail.assigned_to = this.assignTo;
-      this.assignTo = '';
-    });
+    await this.svc.assign(this.selectedEmail.id, this.assignTo);
+    this.selectedEmail.assigned_to = this.assignTo;
+    this.assignTo = '';
   }
 }


### PR DESCRIPTION
## Summary
- add tRPC router for email operations
- use promise-based tRPC calls in email service and client
- update email client test for new service pattern

## Testing
- `CI=1 npx nx test backend`
- `CI=1 npx nx test frontend`
- `CI=1 npx nx lint backend`
- `CI=1 npx nx lint frontend`


------
https://chatgpt.com/codex/tasks/task_e_6897973dea608321850692519c32d50e