### PR TITLE
docs: document backend routes

### DIFF
--- a/apps/backend/src/app/routes/auth/auth.route.spec.ts
+++ b/apps/backend/src/app/routes/auth/auth.route.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * Integration tests for authentication REST routes.
+ */
 import Fastify from 'fastify';
 import { AuthController } from '../../controllers/auth.controller';
 

--- a/apps/backend/src/app/routes/auth/auth.route.ts
+++ b/apps/backend/src/app/routes/auth/auth.route.ts
@@ -1,3 +1,6 @@
+/**
+ * Registers REST endpoints for authentication-related operations.
+ */
 import { FastifyPluginCallback, FastifyRequest } from 'fastify';
 
 import { AuthController } from '../../controllers/auth.controller';
@@ -6,7 +9,11 @@ import { IdParam } from '../fastify.types';
 const auth = new AuthController();
 
 /**
- * Supported HTTP routes for the auth endpoint
+ * Supported HTTP routes for the auth endpoint.
+ *
+ * @param fastify - The Fastify instance used to register routes.
+ * @param _ - Unused options object.
+ * @param done - Callback to signal completion of route registration.
  */
 const routes: FastifyPluginCallback = (fastify, _, done) => {
   fastify.get('', (req: FastifyRequest) => auth.getAll(req.headers['tenant-id'] as string));

--- a/apps/backend/src/app/routes/emails/emails.route.spec.ts
+++ b/apps/backend/src/app/routes/emails/emails.route.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * Integration tests for email REST routes.
+ */
 import Fastify from 'fastify';
 import { EmailsController } from '../../controllers/emails.controller';
 

--- a/apps/backend/src/app/routes/emails/emails.route.ts
+++ b/apps/backend/src/app/routes/emails/emails.route.ts
@@ -1,25 +1,29 @@
+/**
+ * Registers REST routes for email operations such as retrieving folders and messages.
+ */
 import { FastifyPluginCallback, FastifyRequest } from 'fastify';
 import { EmailsController } from '../../controllers/emails.controller';
 import { IdParam } from '../fastify.types';
 
 const emails = new EmailsController();
 
-/** REST routes for email operations */
+/**
+ * Fastify plugin that defines email-related routes.
+ *
+ * @param fastify - The Fastify instance used to register routes.
+ * @param _ - Unused options object.
+ * @param done - Callback to signal completion of route registration.
+ */
 const routes: FastifyPluginCallback = (fastify, _, done) => {
   fastify.get('/folders', (req: FastifyRequest) => emails.getFolders(req.headers['tenant-id'] as string));
   fastify.get('/folder/:folderId', (req: FastifyRequest) =>
     emails.getEmails(req.headers['tenant-id'] as string, (req.params as any).folderId),
   );
   fastify.get('/message/:id', (req: IdParam) => emails.getEmail(req.headers['tenant-id'] as string, req.params.id));
-  fastify.post('/message/:id/comment', (req: FastifyRequest<{ Body: { author_id: string; comment: string } }> ) =>
-    emails.addComment(
-      req.headers['tenant-id'] as string,
-      (req.params as any).id,
-      req.body.author_id,
-      req.body.comment,
-    ),
+  fastify.post('/message/:id/comment', (req: FastifyRequest<{ Body: { author_id: string; comment: string } }>) =>
+    emails.addComment(req.headers['tenant-id'] as string, (req.params as any).id, req.body.author_id, req.body.comment),
   );
-  fastify.post('/message/:id/assign', (req: FastifyRequest<{ Body: { user_id: string } }> ) =>
+  fastify.post('/message/:id/assign', (req: FastifyRequest<{ Body: { user_id: string } }>) =>
     emails.assignEmail(req.headers['tenant-id'] as string, (req.params as any).id, req.body.user_id),
   );
   done();

--- a/apps/backend/src/app/routes/fastify.types.ts
+++ b/apps/backend/src/app/routes/fastify.types.ts
@@ -1,5 +1,11 @@
+/**
+ * Shared Fastify request type definitions used across route files.
+ */
 import { FastifyRequest } from 'fastify';
 
+/**
+ * Fastify request type that includes a single `id` path parameter.
+ */
 export type IdParam = FastifyRequest<{
   Params: { id: string };
 }>;

--- a/apps/backend/src/app/routes/households/households.route.spec.ts
+++ b/apps/backend/src/app/routes/households/households.route.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * Integration tests for household REST routes.
+ */
 import Fastify from 'fastify';
 import { HouseholdsController } from '../../controllers/households.controller';
 

--- a/apps/backend/src/app/routes/households/households.route.ts
+++ b/apps/backend/src/app/routes/households/households.route.ts
@@ -1,3 +1,6 @@
+/**
+ * Registers REST routes for household operations.
+ */
 import { FastifyPluginCallback, FastifyRequest } from 'fastify';
 
 import { HouseholdsController } from '../../controllers/households.controller';
@@ -7,18 +10,18 @@ import { IdParam } from '../fastify.types';
 const households = new HouseholdsController();
 
 /**
- * Supported HTTP routes for the households endpoint
+ * Supported HTTP routes for the households endpoint.
+ *
+ * @param fastify - The Fastify instance used to register routes.
+ * @param _ - Unused options object.
+ * @param done - Callback to signal completion of route registration.
  */
 const routes: FastifyPluginCallback = (fastify, _, done) => {
-  fastify.get('', schema.getAll, (req: FastifyRequest) =>
-    households.getAll(req.headers['tenant-id'] as string),
-  );
+  fastify.get('', schema.getAll, (req: FastifyRequest) => households.getAll(req.headers['tenant-id'] as string));
   fastify.get('/:id', schema.findFromId, (req: IdParam) =>
     households.getById({ tenant_id: req.headers['tenant-id'] as string, id: req.params.id }),
   );
-  fastify.get('/count', schema.count, (req: FastifyRequest) =>
-    households.getCount(req.headers['tenant-id'] as string),
-  );
+  fastify.get('/count', schema.count, (req: FastifyRequest) => households.getCount(req.headers['tenant-id'] as string));
 
   done();
 };

--- a/apps/backend/src/app/routes/households/households.schema.ts
+++ b/apps/backend/src/app/routes/households/households.schema.ts
@@ -1,4 +1,7 @@
-// This generally matches the dB schema found in kysely.models, but it doesn't have to
+/**
+ * JSON schema definitions for household-related routes.
+ * This generally matches the database schema found in `kysely.models`, but it can differ.
+ */
 const HouseholdsType = {
   id: { type: 'string' },
   tenant_id: { type: 'string' },
@@ -19,30 +22,36 @@ const HouseholdsType = {
   created_at: { type: 'string' },
   updated_at: { type: 'string' },
 };
+/** Schema for a single household object. */
 const household = {
   type: 'object',
   properties: HouseholdsType,
 };
+/** Schema for an array of household objects. */
 const households = {
   type: 'array',
   items: HouseholdsType,
 };
 
+/** Schema for route parameters containing a household ID. */
 export const IdParam = {
   type: 'object',
   properties: { id: { type: 'string' } },
 };
+/** Schema for the response when counting households. */
 export const count = {
   schema: {
     response: { 200: { type: 'number' } },
   },
 };
+/** Schema for retrieving a household by ID. */
 export const findFromId = {
   schema: {
     params: IdParam,
     response: { 200: household },
   },
 };
+/** Schema for retrieving all households. */
 export const getAll = {
   schema: {
     response: {
@@ -50,6 +59,7 @@ export const getAll = {
     },
   },
 };
+/** Schema for updating a household. */
 export const update = {
   schema: {
     body: {

--- a/apps/backend/src/app/routes/persons/persons.route.spec.ts
+++ b/apps/backend/src/app/routes/persons/persons.route.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * Integration tests for person REST routes.
+ */
 import Fastify from 'fastify';
 import { PersonsController } from '../../controllers/persons.controller';
 
@@ -8,9 +11,9 @@ describe('persons REST routes', () => {
 
   beforeAll(async () => {
     jest.spyOn(PersonsController.prototype, 'getAll').mockResolvedValue(rows as any);
-    jest.spyOn(PersonsController.prototype, 'getById').mockImplementation(async ({ id }) =>
-      rows.find((r) => r.id === id) as any,
-    );
+    jest
+      .spyOn(PersonsController.prototype, 'getById')
+      .mockImplementation(async ({ id }) => rows.find((r) => r.id === id) as any);
     jest.spyOn(PersonsController.prototype, 'getCount').mockResolvedValue(rows.length);
 
     const routes = (await import('./persons.route')).default;

--- a/apps/backend/src/app/routes/persons/persons.route.ts
+++ b/apps/backend/src/app/routes/persons/persons.route.ts
@@ -1,3 +1,6 @@
+/**
+ * Registers REST routes for person operations.
+ */
 import { FastifyPluginCallback, FastifyRequest } from 'fastify';
 
 import { PersonsController } from '../../controllers/persons.controller';
@@ -7,18 +10,18 @@ import { IdParam } from '../fastify.types';
 const persons = new PersonsController();
 
 /**
- * Supported HTTP routes for the persons endpoint
+ * Supported HTTP routes for the persons endpoint.
+ *
+ * @param fastify - The Fastify instance used to register routes.
+ * @param _ - Unused options object.
+ * @param done - Callback to signal completion of route registration.
  */
 const routes: FastifyPluginCallback = (fastify, _, done) => {
-  fastify.get('', schema.getAll, (req: FastifyRequest) =>
-    persons.getAll(req.headers['tenant-id'] as string),
-  );
+  fastify.get('', schema.getAll, (req: FastifyRequest) => persons.getAll(req.headers['tenant-id'] as string));
   fastify.get('/:id', schema.findFromId, (req: IdParam) =>
     persons.getById({ tenant_id: req.headers['tenant-id'] as string, id: req.params.id }),
   );
-  fastify.get('/count', schema.count, (req: FastifyRequest) =>
-    persons.getCount(req.headers['tenant-id'] as string),
-  );
+  fastify.get('/count', schema.count, (req: FastifyRequest) => persons.getCount(req.headers['tenant-id'] as string));
 
   done();
 };

--- a/apps/backend/src/app/routes/persons/persons.schema.ts
+++ b/apps/backend/src/app/routes/persons/persons.schema.ts
@@ -1,4 +1,7 @@
-// This generally matches the dB schema found in kysely.models, but it doesn't have to
+/**
+ * JSON schema definitions for person-related routes.
+ * This generally matches the database schema found in `kysely.models`, but it can differ.
+ */
 const PersonType = {
   id: { type: 'string' },
   tenant_id: { type: 'string' },
@@ -24,30 +27,36 @@ const PersonType = {
   created_at: { type: 'string' },
   updated_at: { type: 'string' },
 };
+/** Schema for a single person object. */
 const person = {
   type: 'object',
   properties: PersonType,
 };
+/** Schema for an array of person objects. */
 const persons = {
   type: 'array',
   items: PersonType,
 };
 
+/** Schema for route parameters containing a person ID. */
 export const IdParam = {
   type: 'object',
   properties: { id: { type: 'string' } },
 };
+/** Schema for the response when counting persons. */
 export const count = {
   schema: {
     response: { 200: { type: 'number' } },
   },
 };
+/** Schema for retrieving a person by ID. */
 export const findFromId = {
   schema: {
     params: IdParam,
     response: { 200: person },
   },
 };
+/** Schema for retrieving all persons. */
 export const getAll = {
   schema: {
     response: {
@@ -55,6 +64,7 @@ export const getAll = {
     },
   },
 };
+/** Schema for updating a person. */
 export const update = {
   schema: {
     body: {


### PR DESCRIPTION
## Summary
- add shared JSDoc for Fastify route types
- document auth, email, household, and person routes and schemas
- annotate route test suites with JSDoc file descriptions

## Testing
- `npx nx test backend`
- `npx nx lint backend`


------
https://chatgpt.com/codex/tasks/task_e_6897a6d086a88321a979c9f6792aae73