### PR TITLE
docs: add JSDoc to TRPC routers and tests

### DIFF
--- a/apps/backend/src/app/trpc-routers/auth.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/auth.router.spec.ts
@@ -1,10 +1,16 @@
+/**
+ * Unit tests for `AuthRouter` ensuring authentication procedures
+ * delegate to the underlying controller and return expected results.
+ */
 import { AuthController } from '../controllers/auth.controller';
 import { AuthRouter } from './auth.router';
 
+/** Test suite for authentication router procedures. */
 describe('AuthRouter', () => {
   const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
   let caller: ReturnType<typeof AuthRouter.createCaller>;
 
+  /** Mock controller methods and create a router caller. */
   beforeAll(() => {
     jest.spyOn(AuthController.prototype, 'signUp').mockResolvedValue({ ok: true } as any);
     jest.spyOn(AuthController.prototype, 'signIn').mockResolvedValue({ auth_token: 'a' } as any);
@@ -20,36 +26,44 @@ describe('AuthRouter', () => {
     caller = AuthRouter.createCaller(ctx);
   });
 
+  /** Restore all mocked controller methods. */
   afterAll(() => {
     jest.restoreAllMocks();
   });
 
+  /** Verifies the sign-up procedure returns the expected result. */
   it('signs up', async () => {
     await expect(
       caller.signUp({ organization: 'Org', email: 'a@b.com', password: 'password1', first_name: 'A' }),
     ).resolves.toEqual({ ok: true });
   });
 
+  /** Verifies the sign-in procedure returns an auth token. */
   it('signs in', async () => {
     await expect(caller.signIn({ email: 'a@b.com', password: 'password1' })).resolves.toEqual({ auth_token: 'a' });
   });
 
+  /** Ensures sign-out returns a success flag. */
   it('signs out', async () => {
     await expect(caller.signOut()).resolves.toBeTruthy();
   });
 
+  /** Retrieves the currently authenticated user. */
   it('gets current user', async () => {
     await expect(caller.currentUser()).resolves.toEqual({ id: '1' });
   });
 
+  /** Tests the password reset workflow. */
   it('resets password', async () => {
     await expect(caller.resetPassword({ password: 'newpass1', code: '123' })).resolves.toBeUndefined();
   });
 
+  /** Validates token renewal provides a new auth and refresh token. */
   it('renews auth token', async () => {
     await expect(caller.renewAuthToken({ auth_token: 'a', refresh_token: 'r' })).resolves.toEqual({ auth_token: 'a', refresh_token: 'r' });
   });
 
+  /** Ensures a password reset email is sent. */
   it('sends password reset email', async () => {
     await expect(caller.sendPasswordResetEmail({ email: 'a@b.com' })).resolves.toBeTruthy();
   });

--- a/apps/backend/src/app/trpc-routers/auth.router.ts
+++ b/apps/backend/src/app/trpc-routers/auth.router.ts
@@ -1,3 +1,7 @@
+/**
+ * tRPC router defining authentication-related procedures such as
+ * sign-up, sign-in, token renewal, and password reset flows.
+ */
 import { signInInputObj, signUpInputObj } from '@common';
 
 import z from 'zod';

--- a/apps/backend/src/app/trpc-routers/emails.router.ts
+++ b/apps/backend/src/app/trpc-routers/emails.router.ts
@@ -1,3 +1,7 @@
+/**
+ * tRPC router for email management including folders, individual emails,
+ * comments, and assignment of emails to users.
+ */
 import { z } from 'zod';
 
 import { authProcedure, router } from '../../trpc';
@@ -5,35 +9,50 @@ import { EmailsController } from '../controllers/emails.controller';
 
 const emails = new EmailsController();
 
+/** Retrieve all email folders for the current tenant. */
 function getFolders() {
   return authProcedure.query(({ ctx }) => emails.getFolders(ctx.auth.tenant_id));
 }
 
+/**
+ * Retrieve emails within a specified folder for the tenant.
+ * @returns A list of email summaries.
+ */
 function getEmails() {
   return authProcedure
     .input(z.object({ folderId: z.string() }))
     .query(({ input, ctx }) => emails.getEmails(ctx.auth.tenant_id, input.folderId));
 }
 
+/**
+ * Retrieve a single email by its ID.
+ * @returns The requested email record.
+ */
 function getEmail() {
   return authProcedure.input(z.string()).query(({ input, ctx }) => emails.getEmail(ctx.auth.tenant_id, input));
 }
 
+/**
+ * Add a comment to an existing email.
+ * @returns The newly created comment record.
+ */
 function addComment() {
   return authProcedure
     .input(z.object({ id: z.string(), author_id: z.string(), comment: z.string() }))
     .mutation(({ input, ctx }) => emails.addComment(ctx.auth.tenant_id, input.id, input.author_id, input.comment));
 }
 
+/**
+ * Assign an email to a specific user for follow-up.
+ * @returns Success status of the assignment.
+ */
 function assign() {
   return authProcedure
     .input(z.object({ id: z.string(), user_id: z.string() }))
     .mutation(({ input, ctx }) => emails.assignEmail(ctx.auth.tenant_id, input.id, input.user_id));
 }
 
-/**
- * Emails endpoints
- */
+/** Router exposing email-related procedures. */
 export const EmailsRouter = router({
   getFolders: getFolders(),
   getEmails: getEmails(),

--- a/apps/backend/src/app/trpc-routers/households.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/households.router.spec.ts
@@ -1,10 +1,16 @@
+/**
+ * Unit tests for `HouseholdsRouter` ensuring household procedures
+ * delegate correctly to the controller and produce expected results.
+ */
 import { HouseholdsController } from '../controllers/households.controller';
 import { HouseholdsRouter } from './households.router';
 
+/** Test suite for household-related router procedures. */
 describe('HouseholdsRouter', () => {
   const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
   let caller: ReturnType<typeof HouseholdsRouter.createCaller>;
 
+  /** Mock controller methods and create a router caller. */
   beforeAll(() => {
     jest.spyOn(HouseholdsController.prototype, 'addHousehold').mockResolvedValue({ id: '1' } as any);
     jest.spyOn(HouseholdsController.prototype, 'attachTag').mockResolvedValue(true as any);
@@ -21,54 +27,67 @@ describe('HouseholdsRouter', () => {
     caller = HouseholdsRouter.createCaller(ctx);
   });
 
+  /** Restore mocked methods after tests complete. */
   afterAll(() => {
     jest.restoreAllMocks();
   });
 
+  /** Tests adding a household returns the created ID. */
   it('adds a household', async () => {
     await expect(caller.add({} as any)).resolves.toEqual({ id: '1' });
   });
 
+  /** Tests attaching a tag to a household. */
   it('attaches a tag', async () => {
     await expect(caller.attachTag({ id: '1', tag_name: 't' })).resolves.toBeTruthy();
   });
 
+  /** Tests counting households for the tenant. */
   it('counts households', async () => {
     await expect(caller.count()).resolves.toBe(1);
   });
 
+  /** Tests deletion of multiple households. */
   it('deletes many households', async () => {
     await expect(caller.deleteMany(['1'])).resolves.toBeTruthy();
   });
 
+  /** Tests deletion of a single household. */
   it('deletes a household', async () => {
     await expect(caller.delete('1')).resolves.toBeTruthy();
   });
 
+  /** Tests detaching a tag from a household. */
   it('detaches tag', async () => {
     await expect(caller.detachTag({ id: '1', tag_name: 't' })).resolves.toBeUndefined();
   });
 
+  /** Tests retrieval of all households. */
   it('gets all households', async () => {
     await expect(caller.getAll()).resolves.toEqual([{ id: '1' }]);
   });
 
+  /** Tests retrieval of households with aggregated people counts. */
   it('gets all with people count', async () => {
     await expect(caller.getAllWithPeopleCount({} as any)).resolves.toEqual({ rows: [], count: 0 });
   });
 
+  /** Tests retrieving a household by ID. */
   it('gets household by id', async () => {
     await expect(caller.getById('1')).resolves.toEqual({ id: '1' });
   });
 
+  /** Tests retrieving distinct household tags. */
   it('gets distinct tags', async () => {
     await expect(caller.getDistinctTags()).resolves.toEqual(['a']);
   });
 
+  /** Tests retrieving tags for a household. */
   it('gets tags', async () => {
     await expect(caller.getTags('1')).resolves.toEqual(['a']);
   });
 
+  /** Tests updating household details. */
   it('updates household', async () => {
     await expect(caller.update({ id: '1', data: {} as any })).resolves.toEqual({ id: '1' });
   });

--- a/apps/backend/src/app/trpc-routers/households.router.ts
+++ b/apps/backend/src/app/trpc-routers/households.router.ts
@@ -1,3 +1,7 @@
+/**
+ * tRPC router providing CRUD operations and tag management for
+ * household records within a tenant.
+ */
 import { UpdateHouseholdsObj, getAllOptions } from '@common';
 
 import { z } from 'zod';
@@ -25,6 +29,10 @@ function attachTag() {
     .mutation(({ input, ctx }) => households.attachTag(input.id, input.tag_name, ctx.auth));
 }
 
+/**
+ * Get the total number of households for the current tenant.
+ * @returns Count of household records.
+ */
 function count() {
   return authProcedure.query(({ ctx }) => households.getCount(ctx.auth.tenant_id));
 }

--- a/apps/backend/src/app/trpc-routers/index.ts
+++ b/apps/backend/src/app/trpc-routers/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Entry point that aggregates all application tRPC routers and
+ * re-exports individual routers for convenience.
+ */
 import { router } from '../../trpc';
 import { AuthRouter } from './auth.router';
 import { HouseholdsRouter } from './households.router';

--- a/apps/backend/src/app/trpc-routers/persons.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/persons.router.spec.ts
@@ -1,10 +1,16 @@
+/**
+ * Unit tests for `PersonsRouter` verifying person procedures delegate
+ * correctly to the controller and return expected results.
+ */
 import { PersonsController } from '../controllers/persons.controller';
 import { PersonsRouter } from './persons.router';
 
+/** Test suite for person-related router procedures. */
 describe('PersonsRouter', () => {
   const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
   let caller: ReturnType<typeof PersonsRouter.createCaller>;
 
+  /** Mock controller methods and create router caller. */
   beforeAll(() => {
     jest.spyOn(PersonsController.prototype, 'addPerson').mockResolvedValue({ id: '1' } as any);
     jest.spyOn(PersonsController.prototype, 'getAll').mockResolvedValue([{ id: '1' }] as any);
@@ -13,22 +19,27 @@ describe('PersonsRouter', () => {
     caller = PersonsRouter.createCaller(ctx);
   });
 
+  /** Restore mocked methods after tests. */
   afterAll(() => {
     jest.restoreAllMocks();
   });
 
+  /** Tests adding a person returns the new ID. */
   it('adds a person', async () => {
     await expect(caller.add({})).resolves.toEqual({ id: '1' });
   });
 
+  /** Tests retrieving all persons. */
   it('gets all persons', async () => {
     await expect(caller.getAll({} as any)).resolves.toEqual([{ id: '1' }]);
   });
 
+  /** Tests deleting a person by ID. */
   it('deletes a person', async () => {
     await expect(caller.delete('1')).resolves.toBeTruthy();
   });
 
+  /** Tests counting persons for the tenant. */
   it('counts persons', async () => {
     await expect(caller.count()).resolves.toBe(1);
   });

--- a/apps/backend/src/app/trpc-routers/persons.router.ts
+++ b/apps/backend/src/app/trpc-routers/persons.router.ts
@@ -1,3 +1,7 @@
+/**
+ * tRPC router offering CRUD operations, tag management, and queries
+ * for person records associated with a tenant.
+ */
 import { UpdatePersonsObj, getAllOptions } from '@common';
 
 import { z } from 'zod';
@@ -22,6 +26,10 @@ function attachTag() {
     .mutation(({ input, ctx }) => persons.attachTag(input.id, input.tag_name, ctx.auth));
 }
 
+/**
+ * Get the total number of people for the current tenant.
+ * @returns Count of person records.
+ */
 function count() {
   return authProcedure.query(({ ctx }) => persons.getCount(ctx.auth.tenant_id));
 }

--- a/apps/backend/src/app/trpc-routers/settings.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/settings.router.spec.ts
@@ -1,20 +1,30 @@
+/**
+ * Unit tests for `SettingsRouter` verifying retrieval of settings
+ * such as the current campaign identifier.
+ */
 import { TRPCError } from '@trpc/server';
 import { SettingsController } from '../controllers/settings.controller';
 import { SettingsRouter } from './settings.router';
 
+/** Test suite for settings-related router procedures. */
 describe('SettingsRouter', () => {
   const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
   let caller: ReturnType<typeof SettingsRouter.createCaller>;
 
+  /** Mock controller methods and create router caller. */
   beforeAll(() => {
     jest.spyOn(SettingsController.prototype, 'getCurrentCampaignId').mockResolvedValue(1 as any);
     caller = SettingsRouter.createCaller(ctx);
   });
 
+  /** Restore mocked methods after tests. */
   afterAll(() => {
     jest.restoreAllMocks();
   });
 
+  /**
+   * Ensures an error is thrown when the stored campaign ID is not a valid number.
+   */
   it('throws when current campaign id is not "number" string', async () => {
     await expect(caller.getCurrentCampaignId()).rejects.toBeInstanceOf(TRPCError);
   });

--- a/apps/backend/src/app/trpc-routers/settings.router.ts
+++ b/apps/backend/src/app/trpc-routers/settings.router.ts
@@ -1,10 +1,14 @@
+/**
+ * tRPC router for application settings such as retrieving active campaigns.
+ */
 import { TRPCError } from '@trpc/server';
 
 import { authProcedure, router } from '../../trpc';
 import { SettingsController } from '../controllers/settings.controller';
 
 /**
- * Get a current campaign for the current tenant.
+ * Retrieve the current campaign identifier for the tenant.
+ * @throws TRPCError if the value is not found or invalid.
  */
 function getCurrentCampaignId() {
   return authProcedure.query(async ({ ctx }) => {
@@ -23,9 +27,7 @@ function getCurrentCampaignId() {
 
 const settings = new SettingsController();
 
-/**
- * Settings endpoints
- */
+/** Router exposing settings-related procedures. */
 export const SettingsRouter = router({
   getCurrentCampaignId: getCurrentCampaignId(),
 });

--- a/apps/backend/src/app/trpc-routers/tags.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/tags.router.spec.ts
@@ -1,10 +1,16 @@
+/**
+ * Unit tests for `TagsRouter` verifying tag operations such as creation,
+ * deletion, and lookup delegate correctly to the controller.
+ */
 import { TagsController } from '../controllers/tags.controller';
 import { TagsRouter } from './tags.router';
 
+/** Test suite for tag-related router procedures. */
 describe('TagsRouter', () => {
   const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
   let caller: ReturnType<typeof TagsRouter.createCaller>;
 
+  /** Mock controller methods and create router caller. */
   beforeAll(() => {
     jest.spyOn(TagsController.prototype, 'addTag').mockResolvedValue({ id: '1' } as any);
     jest.spyOn(TagsController.prototype, 'getCount').mockResolvedValue(1);
@@ -18,42 +24,52 @@ describe('TagsRouter', () => {
     caller = TagsRouter.createCaller(ctx);
   });
 
+  /** Restore mocked methods after tests. */
   afterAll(() => {
     jest.restoreAllMocks();
   });
 
+  /** Tests adding a tag returns the new ID. */
   it('adds a tag', async () => {
     await expect(caller.add({ name: 't' })).resolves.toEqual({ id: '1' });
   });
 
+  /** Tests counting tags for the tenant. */
   it('counts tags', async () => {
     await expect(caller.count()).resolves.toBe(1);
   });
 
+  /** Tests retrieving all tags. */
   it('gets all tags', async () => {
     await expect(caller.getAll()).resolves.toEqual([{ id: '1' }]);
   });
 
+  /** Tests updating a tag by ID. */
   it('updates a tag', async () => {
     await expect(caller.update({ id: '1', data: { name: 'n' } })).resolves.toEqual({ id: '1' });
   });
 
+  /** Tests retrieving a tag by ID. */
   it('gets tag by id', async () => {
     await expect(caller.getById('1')).resolves.toEqual({ id: '1' });
   });
 
+  /** Tests deleting a tag by ID. */
   it('deletes a tag', async () => {
     await expect(caller.delete('1')).resolves.toBeTruthy();
   });
 
+  /** Tests deleting multiple tags at once. */
   it('deletes many tags', async () => {
     await expect(caller.deleteMany(['1'])).resolves.toBeTruthy();
   });
 
+  /** Tests searching tags by name. */
   it('finds by name', async () => {
     await expect(caller.findByName('a')).resolves.toEqual([{ id: '1' }]);
   });
 
+  /** Tests retrieving tags along with usage counts. */
   it('gets all with counts', async () => {
     await expect(caller.getAllWithCounts({} as any)).resolves.toEqual({ rows: [], count: 0 });
   });

--- a/apps/backend/src/app/trpc-routers/tags.router.ts
+++ b/apps/backend/src/app/trpc-routers/tags.router.ts
@@ -1,3 +1,7 @@
+/**
+ * tRPC router handling tag creation, modification, deletion, and search
+ * operations for tenant-specific tags.
+ */
 import { AddTagObj, UpdateTagObj, getAllOptions } from '@common';
 
 import { z } from 'zod';
@@ -12,6 +16,10 @@ function add() {
   return authProcedure.input(AddTagObj).mutation(({ input, ctx }) => tags.addTag(input, ctx.auth));
 }
 
+/**
+ * Get the total number of tags for the current tenant.
+ * @returns Count of tag records.
+ */
 function count() {
   return authProcedure.query(({ ctx }) => tags.getCount(ctx.auth.tenant_id));
 }
@@ -73,9 +81,7 @@ function update() {
 
 const tags = new TagsController();
 
-/**
- * Tags endpoints
- */
+/** Router exposing tag-related procedures. */
 export const TagsRouter = router({
   add: add(),
   count: count(),

--- a/apps/backend/src/app/trpc-routers/userprofiles.router.ts
+++ b/apps/backend/src/app/trpc-routers/userprofiles.router.ts
@@ -1,3 +1,6 @@
+/**
+ * tRPC router exposing endpoints for managing user profile data.
+ */
 import { z } from 'zod';
 
 import { authProcedure, router } from '../../trpc';


### PR DESCRIPTION
## Summary
- document authentication, email, household, person, settings, tag, and user profile routers with file and function JSDoc
- add contextual JSDoc comments throughout router test suites
- annotate index to clarify aggregation of all routers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing parameter 'recommendedConfig' in FlatCompat constructor)*

------
https://chatgpt.com/codex/tasks/task_e_6897a6d9e2a483218169ff03c2f55c14