### PR TITLE
docs: document auth module with JSDoc

### DIFF
--- a/apps/frontend/src/app/auth/auth-guard.spec.ts
+++ b/apps/frontend/src/app/auth/auth-guard.spec.ts
@@ -1,6 +1,15 @@
+/**
+ * Unit tests for the authentication route guard.
+ */
 import * as exported from './auth-guard';
 
+/**
+ * Test suite verifying the auth guard export.
+ */
 describe('auth-guard', () => {
+  /**
+   * Ensures the guard module is defined and accessible.
+   */
   it('should be defined', () => {
     expect(exported).toBeDefined();
   });

--- a/apps/frontend/src/app/auth/auth-guard.ts
+++ b/apps/frontend/src/app/auth/auth-guard.ts
@@ -1,3 +1,6 @@
+/**
+ * Angular route guard that ensures only authenticated users can access certain routes.
+ */
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 

--- a/apps/frontend/src/app/auth/auth-service.spec.ts
+++ b/apps/frontend/src/app/auth/auth-service.spec.ts
@@ -1,6 +1,15 @@
+/**
+ * Unit tests for the authentication service.
+ */
 import * as exported from './auth-service';
 
+/**
+ * Test suite verifying the AuthService export.
+ */
 describe('auth-service', () => {
+  /**
+   * Ensures the service is defined.
+   */
   it('should be defined', () => {
     expect(exported).toBeDefined();
   });

--- a/apps/frontend/src/app/auth/auth-service.ts
+++ b/apps/frontend/src/app/auth/auth-service.ts
@@ -1,3 +1,6 @@
+/**
+ * Service managing authentication state and interactions with backend APIs.
+ */
 import { Injectable, signal } from '@angular/core';
 import { IAuthUser, IToken, signInInputType, signUpInputType } from '@common';
 import { TRPCError } from '@trpc/server';

--- a/apps/frontend/src/app/auth/login-guard.spec.ts
+++ b/apps/frontend/src/app/auth/login-guard.spec.ts
@@ -1,6 +1,15 @@
+/**
+ * Unit tests for the login guard preventing authenticated users from accessing login pages.
+ */
 import * as exported from './login-guard';
 
+/**
+ * Test suite verifying the login guard export.
+ */
 describe('login-guard', () => {
+  /**
+   * Ensures the guard module is defined.
+   */
   it('should be defined', () => {
     expect(exported).toBeDefined();
   });

--- a/apps/frontend/src/app/auth/login-guard.ts
+++ b/apps/frontend/src/app/auth/login-guard.ts
@@ -1,3 +1,6 @@
+/**
+ * Guard that redirects already-authenticated users away from login-related routes.
+ */
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 

--- a/apps/frontend/src/app/auth/new-password-page.html
+++ b/apps/frontend/src/app/auth/new-password-page.html
@@ -1,3 +1,4 @@
+<!-- Template for setting a new password after verifying a reset code. -->
 <div class="bg-image flex min-h-screen font-light" data-theme="light">
   <div class="card card-compact glass m-auto w-96 shadow-xl">
     <div class="card-title bg-primary mb-10 w-full">

--- a/apps/frontend/src/app/auth/new-password-page.spec.ts
+++ b/apps/frontend/src/app/auth/new-password-page.spec.ts
@@ -1,6 +1,15 @@
+/**
+ * Unit tests for the new password page component.
+ */
 import * as exported from './new-password-page';
 
+/**
+ * Test suite verifying the NewPasswordPage export.
+ */
 describe('new-password-page', () => {
+  /**
+   * Ensures the component is defined.
+   */
   it('should be defined', () => {
     expect(exported).toBeDefined();
   });

--- a/apps/frontend/src/app/auth/new-password-page.ts
+++ b/apps/frontend/src/app/auth/new-password-page.ts
@@ -1,3 +1,6 @@
+/**
+ * Component allowing a user to set a new password using a reset code.
+ */
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -14,6 +17,9 @@ import { AuthService } from 'apps/frontend/src/app/auth/auth-service';
   imports: [CommonModule, ReactiveFormsModule, RouterLink, PasswordCheckerModule, Icon, Alerts],
   templateUrl: './new-password-page.html',
 })
+/**
+ * Page component presenting a form to choose a new password.
+ */
 export class NewPasswordPage implements OnInit {
   private readonly alertSvc = inject(AlertService);
   private readonly authService = inject(AuthService);
@@ -36,6 +42,7 @@ export class NewPasswordPage implements OnInit {
   /** Success message to show after successful password reset */
   protected success: string | undefined;
 
+  /** Reactive form with the new password control */
   public form = this.fb.group({
     password: ['', [Validators.required, Validators.minLength(8)]],
   });
@@ -63,6 +70,9 @@ export class NewPasswordPage implements OnInit {
     return this.hidePassword ? 'eye-slash' : 'eye';
   }
 
+  /**
+   * Initializes component state by reading the reset code from the URL.
+   */
   public async ngOnInit() {
     const code = this.route.snapshot.queryParamMap.get('code');
 

--- a/apps/frontend/src/app/auth/reset-password-page.html
+++ b/apps/frontend/src/app/auth/reset-password-page.html
@@ -1,3 +1,4 @@
+<!-- Template for requesting a password reset email. -->
 <div class="bg-image flex min-h-screen font-light" data-theme="light">
   <div class="card card-compact glass m-auto w-96 shadow-xl">
     <div class="card-title bg-primary mb-10 w-full">

--- a/apps/frontend/src/app/auth/reset-password-page.spec.ts
+++ b/apps/frontend/src/app/auth/reset-password-page.spec.ts
@@ -1,6 +1,15 @@
+/**
+ * Unit tests for the reset password page component.
+ */
 import * as exported from './reset-password-page';
 
+/**
+ * Test suite verifying the ResetPasswordPage export.
+ */
 describe('reset-password-page', () => {
+  /**
+   * Ensures the component is defined.
+   */
   it('should be defined', () => {
     expect(exported).toBeDefined();
   });

--- a/apps/frontend/src/app/auth/reset-password-page.ts
+++ b/apps/frontend/src/app/auth/reset-password-page.ts
@@ -1,3 +1,6 @@
+/**
+ * Component for initiating the password reset email flow.
+ */
 import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';

--- a/apps/frontend/src/app/auth/signin-page.html
+++ b/apps/frontend/src/app/auth/signin-page.html
@@ -1,3 +1,4 @@
+<!-- Template for user sign-in with email and password form. -->
 <div class="bg-image flex min-h-screen font-light" data-theme="light">
   <div class="card card-compact glass m-auto w-96 shadow-xl">
     <div class="card-title mb-0 shadow-lg">

--- a/apps/frontend/src/app/auth/signin-page.spec.ts
+++ b/apps/frontend/src/app/auth/signin-page.spec.ts
@@ -1,6 +1,15 @@
+/**
+ * Unit tests for the sign-in page component.
+ */
 import * as exported from './signin-page';
 
+/**
+ * Test suite verifying the SignInPage export.
+ */
 describe('signin-page', () => {
+  /**
+   * Ensures the component is defined.
+   */
   it('should be defined', () => {
     expect(exported).toBeDefined();
   });

--- a/apps/frontend/src/app/auth/signin-page.ts
+++ b/apps/frontend/src/app/auth/signin-page.ts
@@ -1,3 +1,6 @@
+/**
+ * Component handling user sign-in with form validation and persistence options.
+ */
 import { Component, effect, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
@@ -33,14 +36,16 @@ export class SignInPage {
   /** Reference to token persistence setting (localStorage vs session) */
   protected persistence = this.tokenService.getPersistence();
 
-  /** Login form group with email and password fields */
+  /** Form group capturing the user's email and password */
   public form = this.fb.group({
     email: ['', [Validators.required, Validators.email]],
     password: ['', [Validators.required, Validators.minLength(8)]],
   });
 
+  /**
+   * Redirects to the dashboard if an authenticated user revisits the sign-in page.
+   */
   constructor() {
-    // Redirects to dashboard if user is already logged in
     effect(() => {
       if (this.authService.getUser()) this.router.navigate(['console', 'summary']);
     });

--- a/apps/frontend/src/app/auth/signup-page.html
+++ b/apps/frontend/src/app/auth/signup-page.html
@@ -1,3 +1,4 @@
+<!-- Template for user sign-up, capturing account and organization details. -->
 <div class="bg-image flex min-h-screen font-light" data-theme="light">
   <div class="card card-compact glass m-auto w-96 rounded-xl shadow-xl">
     <div class="card-title shadow-lg">

--- a/apps/frontend/src/app/auth/signup-page.spec.ts
+++ b/apps/frontend/src/app/auth/signup-page.spec.ts
@@ -1,6 +1,15 @@
+/**
+ * Unit tests for the sign-up page component.
+ */
 import * as exported from './signup-page';
 
+/**
+ * Test suite verifying the SignUpPage export.
+ */
 describe('signup-page', () => {
+  /**
+   * Ensures the component is defined.
+   */
   it('should be defined', () => {
     expect(exported).toBeDefined();
   });

--- a/apps/frontend/src/app/auth/signup-page.ts
+++ b/apps/frontend/src/app/auth/signup-page.ts
@@ -1,3 +1,6 @@
+/**
+ * Component and form logic for user registration.
+ */
 import { CommonModule } from '@angular/common';
 import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';


### PR DESCRIPTION
## Summary
- document auth guards, services, and pages with JSDoc
- clarify intent in auth unit tests and templates

## Testing
- `npx eslint apps/frontend/src/app/auth/**/*.{ts,html}` (fails: Missing parameter 'recommendedConfig' in FlatCompat constructor)
- `npx jest apps/frontend/src/app/auth/**/*.spec.ts` (fails: Jest encountered an unexpected token; 76 failed test suites)


------
https://chatgpt.com/codex/tasks/task_e_6897a6ed838083219f0559c7ce9e9e82