### PR TITLE
docs: add jsdoc to layout components

### DIFF
--- a/apps/frontend/src/app/layout/dashboards/dashboard.html
+++ b/apps/frontend/src/app/layout/dashboards/dashboard.html
@@ -1,3 +1,4 @@
+<!-- Dashboard layout template combining sidebar, navbar, and routed content -->
 <!-- Sidebar -->
 <div class="drawer drawer-open bg-base-200">
   <input class="drawer-toggle" />

--- a/apps/frontend/src/app/layout/dashboards/dashboard.spec.ts
+++ b/apps/frontend/src/app/layout/dashboards/dashboard.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * Basic unit tests ensuring the Dashboard component exports correctly.
+ */
 import * as exported from './dashboard';
 
 describe('dashboard', () => {

--- a/apps/frontend/src/app/layout/dashboards/dashboard.ts
+++ b/apps/frontend/src/app/layout/dashboards/dashboard.ts
@@ -1,3 +1,7 @@
+/**
+ * Root dashboard component that composes the main layout by combining the
+ * navbar, sidebar, and routed content area.
+ */
 import { Component, inject } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { Alerts } from '@uxcommon/alerts/alerts';
@@ -12,12 +16,20 @@ import { SidebarService } from 'apps/frontend/src/app/layout/sidebar/sidebar-ser
   imports: [Navbar, Sidebar, RouterModule, Breadcrumb, Alerts],
   templateUrl: './dashboard.html',
 })
+/**
+ * Container component used as the shell for dashboard pages.
+ */
 export class Dashboard {
   /**
    * Service that manages the sidebar visibility and toggling logic.
    */
   private readonly sidebarSvc = inject(SidebarService);
 
+  /**
+   * Indicates whether the sidebar is open in mobile view.
+   *
+   * @returns `true` if the sidebar is open on mobile, otherwise `false`.
+   */
   protected isMobileOpen() {
     return this.sidebarSvc.isMobileOpen;
   }

--- a/apps/frontend/src/app/layout/navbar/navbar.html
+++ b/apps/frontend/src/app/layout/navbar/navbar.html
@@ -1,4 +1,4 @@
-<!-- Nav bar -->
+<!-- Navigation bar template with search, theme toggle, and user actions -->
 <div class="navbar bg-base-100 shadow-lg">
   <div class="flex-1 sm:hidden" (click)="toggleMobile()">
     <pc-icon name="bars-4"></pc-icon>

--- a/apps/frontend/src/app/layout/navbar/navbar.spec.ts
+++ b/apps/frontend/src/app/layout/navbar/navbar.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * Basic unit tests ensuring the Navbar component exports correctly.
+ */
 import * as exported from './navbar';
 
 describe('navbar', () => {

--- a/apps/frontend/src/app/layout/navbar/navbar.ts
+++ b/apps/frontend/src/app/layout/navbar/navbar.ts
@@ -1,3 +1,6 @@
+/**
+ * Navigation bar component providing search, theme switching, and user actions.
+ */
 import { Component, ElementRef, HostListener, ViewChild, effect, inject, signal } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { AnimateIfDirective } from '@uxcommon/animate-if.directive';
@@ -14,6 +17,9 @@ import { ThemeService } from 'apps/frontend/src/app/layout/theme-service';
   imports: [Icon, Swap, ReactiveFormsModule, AnimateIfDirective],
   templateUrl: './navbar.html',
 })
+/**
+ * Top-level navigation bar displayed across the application.
+ */
 export class Navbar {
   private readonly auth = inject(AuthService);
   private readonly searchSvc = inject(SearchService);
@@ -53,6 +59,8 @@ export class Navbar {
   /**
    * Listen for Ctrl + K or Cmd + K to open search.
    * Prevents default browser behavior.
+   *
+   * @param event - Keyboard event triggered from the window.
    */
   @HostListener('window:keydown', ['$event'])
   public handleKeyDown(event: KeyboardEvent): void {
@@ -78,14 +86,15 @@ export class Navbar {
 
   /**
    * Returns whether the mobile sidebar is currently open.
+   *
+   * @returns `true` if the mobile sidebar is visible, otherwise `false`.
    */
   protected isMobileOpen(): boolean {
     return this.sideBarSvc.isMobileOpen;
   }
 
   /**
-   * Hide the search bar on losing focus if the
-   * input text bar is empty
+   * Hides the search bar when it loses focus and the input is empty.
    */
   protected onBlurSearchBar() {
     if (!this.searchStr.length) {

--- a/apps/frontend/src/app/layout/sidebar/sidebar-items.spec.ts
+++ b/apps/frontend/src/app/layout/sidebar/sidebar-items.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * Basic unit tests ensuring the sidebar items configuration exports correctly.
+ */
 import * as exported from './sidebar-items';
 
 describe('sidebar-items', () => {

--- a/apps/frontend/src/app/layout/sidebar/sidebar-items.ts
+++ b/apps/frontend/src/app/layout/sidebar/sidebar-items.ts
@@ -1,3 +1,6 @@
+/**
+ * Defines the structure and default list of items displayed in the sidebar navigation.
+ */
 import { IconName } from '@uxcommon/svg-icons-list';
 
 /**
@@ -58,6 +61,9 @@ export interface ISidebarItem {
   type?: 'item' | 'subheading';
 }
 
+/**
+ * Default list of sidebar items used throughout the application.
+ */
 export const SidebarItems: ISidebarItem[] = [
   {
     name: 'Console',

--- a/apps/frontend/src/app/layout/sidebar/sidebar-service.spec.ts
+++ b/apps/frontend/src/app/layout/sidebar/sidebar-service.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * Unit tests covering SidebarService behavior for drawer state and route lookup.
+ */
 import { SidebarService } from './sidebar-service';
 
 describe('SidebarService', () => {

--- a/apps/frontend/src/app/layout/sidebar/sidebar-service.ts
+++ b/apps/frontend/src/app/layout/sidebar/sidebar-service.ts
@@ -1,3 +1,6 @@
+/**
+ * Service responsible for managing sidebar items and drawer open state.
+ */
 import { Injectable } from '@angular/core';
 
 import { ISidebarItem, SidebarItems } from './sidebar-items';
@@ -5,27 +8,32 @@ import { ISidebarItem, SidebarItems } from './sidebar-items';
 @Injectable({
   providedIn: 'root',
 })
+/**
+ * Provides utility methods for controlling the sidebar and retrieving its items.
+ */
 export class SidebarService {
   private _isMobileOpen = false;
   private drawerState: DrawerStates = this.getState();
   private items = SidebarItems;
 
   /**
-   * Is the drawer open on mobile
+   * Indicates whether the drawer is open on mobile devices.
    */
   public get isMobileOpen() {
     return this._isMobileOpen;
   }
 
   /**
-   * Close the sidebar on mobile
+   * Closes the sidebar when viewed on mobile.
    */
   public closeMobile() {
     this._isMobileOpen = false;
   }
 
   /**
-   * Get all the sidebar items.
+   * Retrieves the current set of sidebar items.
+   *
+   * @returns Array of sidebar items.
    */
   public getItems() {
     return this.items;
@@ -47,36 +55,43 @@ export class SidebarService {
   }
 
   /**
-   * Is the drawer fully open
+   * Checks if the drawer is fully expanded.
+   *
+   * @returns `true` when the drawer is open.
    */
   public isFull() {
     return this.drawerState === 'full';
   }
 
   /**
-   * is the drawer half open, showing only the icons
+   * Determines if the drawer is half open, showing only icons.
+   *
+   * @returns `true` when the drawer is half expanded.
    */
   public isHalf() {
     return this.drawerState === 'half';
   }
 
   /**
-   * Set all the sidebar items. Typically it'll be used to update the sidebar,
-   * for instance by adding badges to the sidebar items.
+   * Replaces the sidebar items. Useful for updating badges or visibility.
+   *
+   * @param items - New array of sidebar items to use.
    */
   public setItems(items: ISidebarItem[]) {
     this.items = items;
   }
 
   /**
-   * Togger the drawer state between full and half
+   * Toggles the drawer state between full and half.
+   *
+   * @returns The updated drawer state.
    */
   public toggleDrawer() {
     return this.setState(this.drawerState === 'full' ? 'half' : 'full');
   }
 
   /**
-   * Toggle the drawer on mobile
+   * Toggles the mobile drawer open or closed.
    */
   public toggleMobile() {
     this._isMobileOpen = !this._isMobileOpen;
@@ -95,7 +110,9 @@ export class SidebarService {
   }
 
   /**
-   * Get the currrent drawer state (full or half)
+   * Retrieves the current drawer state from local storage.
+   *
+   * @returns The persisted drawer state.
    */
   private getState(): DrawerStates {
     const state = localStorage.getItem('pc-drawerState');
@@ -103,8 +120,10 @@ export class SidebarService {
   }
 
   /**
-   * Save the drawer state so that it can be restored on page reload
+   * Saves the drawer state to local storage so it can be restored on reload.
    *
+   * @param state - Drawer state to persist.
+   * @returns The stored drawer state.
    */
   private setState(state: DrawerStates) {
     this.drawerState = state;

--- a/apps/frontend/src/app/layout/sidebar/sidebar.html
+++ b/apps/frontend/src/app/layout/sidebar/sidebar.html
@@ -1,3 +1,4 @@
+<!-- Sidebar template containing navigation items and drawer controls -->
 <div
   (mouseenter)="onSidebarHover(true)"
   (mouseleave)="onSidebarHover(false)"

--- a/apps/frontend/src/app/layout/sidebar/sidebar.spec.ts
+++ b/apps/frontend/src/app/layout/sidebar/sidebar.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * Basic unit tests ensuring the Sidebar component exports correctly.
+ */
 import * as exported from './sidebar';
 
 describe('sidebar', () => {

--- a/apps/frontend/src/app/layout/sidebar/sidebar.ts
+++ b/apps/frontend/src/app/layout/sidebar/sidebar.ts
@@ -1,3 +1,6 @@
+/**
+ * Sidebar component rendering navigation links and managing drawer state.
+ */
 import { Component, inject } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { Icon } from '@uxcommon/icon';
@@ -17,6 +20,9 @@ import { SidebarService } from 'apps/frontend/src/app/layout/sidebar/sidebar-ser
     `,
   ],
 })
+/**
+ * Displays the navigation sidebar and delegates state management to SidebarService.
+ */
 export class Sidebar {
   private readonly sidebarSvc = inject(SidebarService);
 
@@ -25,38 +31,80 @@ export class Sidebar {
 
   public hoveringSidebar = false;
 
+  /**
+   * List of sidebar items to render.
+   *
+   * @returns Array of configured sidebar items.
+   */
   protected get items() {
     return this.sidebarSvc.getItems();
   }
 
+  /**
+   * Closes the sidebar when viewed on mobile devices.
+   */
   protected closeMobile() {
     this.sidebarSvc.closeMobile();
   }
 
+  /**
+   * Checks whether a sidebar section is collapsed.
+   *
+   * @param name - The section name to verify.
+   * @returns `true` if the section is collapsed.
+   */
   protected isCollapsed(name: string): boolean {
     return this.collapsedItems.has(name);
   }
 
+  /**
+   * Determines if the drawer is fully open.
+   *
+   * @returns `true` when drawer is fully expanded.
+   */
   protected isDrawerFull() {
     return this.sidebarSvc.isFull();
   }
 
+  /**
+   * Determines if the drawer is half open, showing only icons.
+   *
+   * @returns `true` when drawer is half expanded.
+   */
   protected isDrawerHalf() {
     return this.sidebarSvc.isHalf();
   }
 
+  /**
+   * Indicates whether the mouse is hovering over the sidebar.
+   *
+   * @returns Hovering state of the sidebar.
+   */
   protected isHoveringSidebar() {
     return this.hoveringSidebar;
   }
 
+  /**
+   * Returns whether the sidebar is open in mobile view.
+   */
   protected isMobileOpen() {
     return this.sidebarSvc.isMobileOpen;
   }
 
+  /**
+   * Sets hover state for the sidebar.
+   *
+   * @param state - `true` when the sidebar is being hovered.
+   */
   protected onSidebarHover(state: boolean) {
     this.hoveringSidebar = state;
   }
 
+  /**
+   * Toggles the collapse state of a sidebar section.
+   *
+   * @param name - Name of the section to toggle.
+   */
   protected toggleCollapse(name: string) {
     if (this.collapsedItems.has(name)) {
       this.collapsedItems.delete(name);
@@ -65,6 +113,9 @@ export class Sidebar {
     }
   }
 
+  /**
+   * Toggles the drawer between full and half states.
+   */
   protected toggleDrawer() {
     return this.sidebarSvc.toggleDrawer();
   }

--- a/apps/frontend/src/app/layout/theme-service.spec.ts
+++ b/apps/frontend/src/app/layout/theme-service.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests verifying ThemeService behavior for detecting system preferences and
+ * toggling between light and dark modes.
+ */
 import { ThemeService } from './theme-service';
 
 describe('ThemeService', () => {

--- a/apps/frontend/src/app/layout/theme-service.ts
+++ b/apps/frontend/src/app/layout/theme-service.ts
@@ -1,3 +1,7 @@
+/**
+ * Manages the application's light and dark theme preference using Angular signals
+ * and persists the selection in local storage.
+ */
 import { Injectable, signal } from '@angular/core';
 
 /**


### PR DESCRIPTION
## Summary
- document theme management service
- add high-level JSDoc for dashboard, navbar, and sidebar components
- expand sidebar service comments and file docs throughout layout

## Testing
- `npx nx lint frontend`
- `npx jest apps/frontend/src/app/layout/theme-service.spec.ts` *(fails: Unexpected token in spec)*

------
https://chatgpt.com/codex/tasks/task_e_6897a702984c8321a86c6289dc782cde