### PR TITLE
docs: add JSDoc to frontend features

### DIFF
--- a/apps/frontend/src/app/features/emails/services/emails-service.ts
+++ b/apps/frontend/src/app/features/emails/services/emails-service.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Service for interacting with the email backend via tRPC.
+ */
 import { Injectable } from '@angular/core';
 
 import { TRPCService } from '../../../backend-svc/trpc-service';
@@ -5,22 +8,49 @@ import { TRPCService } from '../../../backend-svc/trpc-service';
 /** Service for interacting with email backend via tRPC */
 @Injectable({ providedIn: 'root' })
 export class EmailsService extends TRPCService<'emails'> {
+  /**
+   * Retrieve the list of available email folders.
+   * @returns Promise resolving to an array of folders
+   */
   getFolders() {
     return this.api.emails.getFolders.query();
   }
 
+  /**
+   * Fetch all emails for a given folder.
+   * @param folderId Identifier of the folder to query
+   * @returns Promise resolving to the emails in the folder
+   */
   getEmails(folderId: string) {
     return this.api.emails.getEmails.query({ folderId });
   }
 
+  /**
+   * Get a single email by its ID.
+   * @param id Email identifier
+   * @returns Promise resolving to the email details
+   */
   getEmail(id: string) {
     return this.api.emails.getEmail.query(id);
   }
 
+  /**
+    * Add a comment to an email.
+    * @param id Email identifier
+    * @param author_id ID of the user adding the comment
+    * @param comment Comment text
+    * @returns Promise for the mutation
+    */
   addComment(id: string, author_id: string, comment: string) {
     return this.api.emails.addComment.mutate({ id, author_id, comment });
   }
 
+  /**
+   * Assign an email to a user.
+   * @param id Email identifier
+   * @param user_id User ID to assign to
+   * @returns Promise for the mutation
+   */
   assign(id: string, user_id: string) {
     return this.api.emails.assign.mutate({ id, user_id });
   }

--- a/apps/frontend/src/app/features/emails/ui/email-client.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client.spec.ts
@@ -1,20 +1,29 @@
+/**
+ * @file Unit tests for the {@link EmailClient} component.
+ */
 import { EmailClient } from './email-client';
 import { EmailsService } from '../services/emails-service';
 
 jest.mock('../services/emails-service', () => ({
+  /** Simple mock implementation of EmailsService for tests */
   EmailsService: class {
+    /** Mock returning a single folder */
     getFolders() {
       return Promise.resolve([{ id: '1', name: 'Inbox' }]);
     }
+    /** Mock returning an empty email list */
     getEmails() {
       return Promise.resolve([]);
     }
+    /** Mock returning a single email with empty comments */
     getEmail() {
       return Promise.resolve({ email: { id: '1', subject: 'a', body: 'b' }, comments: [] });
     }
+    /** Mock for adding a comment */
     addComment() {
       return Promise.resolve(null);
     }
+    /** Mock for assigning an email */
     assign() {
       return Promise.resolve(null);
     }

--- a/apps/frontend/src/app/features/emails/ui/email-client.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Simple email client demonstrating folder and message retrieval.
+ */
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -36,19 +39,33 @@ import { EmailsService } from '../services/emails-service';
   `,
 })
 export class EmailClient implements OnInit {
+  /** List of folders retrieved from the backend */
   folders: any[] = [];
+  /** Emails in the selected folder */
   emails: any[] = [];
+  /** Comments for the selected email */
   comments: any[] = [];
+  /** Currently selected email */
   selectedEmail: any | null = null;
+  /** New comment text */
   newComment = '';
+  /** User ID to assign selected email to */
   assignTo = '';
 
+  /** Injects the EmailsService */
   constructor(private svc: EmailsService) {}
 
+  /**
+   * Lifecycle hook to load folders on initialization.
+   */
   async ngOnInit() {
     this.folders = await this.svc.getFolders();
   }
 
+  /**
+   * Select a folder and load its emails.
+   * @param folder Folder object from the list
+   */
   async selectFolder(folder: any) {
     const e = await this.svc.getEmails(folder.id);
     this.emails = e;
@@ -56,12 +73,19 @@ export class EmailClient implements OnInit {
     this.comments = [];
   }
 
+  /**
+   * Select an email and retrieve its details and comments.
+   * @param email Email object to load
+   */
   async selectEmail(email: any) {
     const res = await this.svc.getEmail(email.id);
     this.selectedEmail = res.email;
     this.comments = res.comments;
   }
 
+  /**
+   * Add a comment to the selected email.
+   */
   async addComment() {
     if (!this.selectedEmail || !this.newComment) return;
     await this.svc.addComment(this.selectedEmail.id, '1', this.newComment);
@@ -69,6 +93,9 @@ export class EmailClient implements OnInit {
     this.newComment = '';
   }
 
+  /**
+   * Assign the selected email to a user.
+   */
   async assign() {
     if (!this.selectedEmail || !this.assignTo) return;
     await this.svc.assign(this.selectedEmail.id, this.assignTo);

--- a/apps/frontend/src/app/features/households/services/households-service.spec.ts
+++ b/apps/frontend/src/app/features/households/services/households-service.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Unit tests for {@link HouseholdsService} verifying interaction with the API layer.
+ */
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { HouseholdsService } from './households-service';

--- a/apps/frontend/src/app/features/households/services/households-service.ts
+++ b/apps/frontend/src/app/features/households/services/households-service.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Service responsible for managing household data via tRPC.
+ */
 import { Injectable } from '@angular/core';
 import { UpdateHouseholdsType, getAllOptionsType } from '@common';
 
@@ -41,6 +44,10 @@ export class HouseholdsService extends AbstractAPIService<'households', never> {
     return this.api.households.attachTag.mutate({ id: id, tag_name });
   }
 
+  /**
+   * Retrieve the total number of households.
+   * @returns Promise resolving to household count
+   */
   public count(): Promise<number> {
     return this.api.households.count.query();
   }

--- a/apps/frontend/src/app/features/households/ui/household-detail.html
+++ b/apps/frontend/src/app/features/households/ui/household-detail.html
@@ -1,3 +1,4 @@
+<!-- Template for household detail view -->
 <div class="flex min-h-full flex-col bg-base-100">
   <progress class="progress w-full" [class.hidden]="!loading()"></progress>
   <form [formGroup]="form" class="mx-5 mt-10 sm:mx-10">

--- a/apps/frontend/src/app/features/households/ui/household-detail.spec.ts
+++ b/apps/frontend/src/app/features/households/ui/household-detail.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Unit tests for the {@link HouseholdDetail} component.
+ */
 jest.mock('@uxcommon/formInput', () => ({ FormInput: class {} }), { virtual: true });
 jest.mock('@uxcommon/input', () => ({ PPlCrmInput: class {} }), { virtual: true });
 jest.mock('@uxcommon/tags/tags', () => ({ Tags: class {} }), { virtual: true });

--- a/apps/frontend/src/app/features/households/ui/household-detail.ts
+++ b/apps/frontend/src/app/features/households/ui/household-detail.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Component for creating or editing households and managing their tags and members.
+ */
 import { Component, OnInit, inject, input, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
@@ -78,6 +81,9 @@ export class HouseholdDetail implements OnInit {
   /** Component mode: 'edit' or 'new' */
   public mode = input<'new' | 'edit'>('edit');
 
+  /**
+   * Initializes the component and captures the household ID in edit mode.
+   */
   constructor() {
     if (this.mode() === 'edit') {
       this.id = this.route.snapshot.paramMap.get('id');

--- a/apps/frontend/src/app/features/households/ui/households-grid.spec.ts
+++ b/apps/frontend/src/app/features/households/ui/households-grid.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Unit tests for {@link HouseholdsGrid} component.
+ */
 jest.mock('@uxcommon/datagrid/datagrid', () => {
   return {
     DataGrid: class {

--- a/apps/frontend/src/app/features/households/ui/households-grid.ts
+++ b/apps/frontend/src/app/features/households/ui/households-grid.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Grid component for listing households with counts and tags.
+ */
 import { Component } from '@angular/core';
 import { UpdateHouseholdsObj } from '@common';
 import { DataGrid } from '@uxcommon/datagrid/datagrid';

--- a/apps/frontend/src/app/features/persons/services/persons-service.spec.ts
+++ b/apps/frontend/src/app/features/persons/services/persons-service.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Basic existence test for {@link PersonsService} exports.
+ */
 import * as exported from './persons-service';
 
 describe('persons-service', () => {

--- a/apps/frontend/src/app/features/persons/services/persons-service.ts
+++ b/apps/frontend/src/app/features/persons/services/persons-service.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Service for managing person records through the tRPC API.
+ */
 import { Injectable } from '@angular/core';
 import { PERSONINHOUSEHOLDTYPE, UpdatePersonsType, getAllOptionsType } from '@common';
 
@@ -45,6 +48,10 @@ export class PersonsService extends AbstractAPIService<DATA_TYPE, UpdatePersonsT
     return this.api.persons.attachTag.mutate({ id: id, tag_name });
   }
 
+  /**
+   * Retrieve the total number of people.
+   * @returns Promise resolving to count of persons
+   */
   public count(): Promise<number> {
     return this.api.persons.count.query();
   }

--- a/apps/frontend/src/app/features/persons/ui/people-in-household.spec.ts
+++ b/apps/frontend/src/app/features/persons/ui/people-in-household.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Smoke tests for {@link PeopleInHousehold} component exports.
+ */
 import * as exported from './people-in-household';
 
 describe('people-in-household', () => {

--- a/apps/frontend/src/app/features/persons/ui/people-in-household.ts
+++ b/apps/frontend/src/app/features/persons/ui/people-in-household.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Component for displaying people associated with a household.
+ */
 import { Component, OnInit, inject, input } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { PERSONINHOUSEHOLDTYPE } from '@common';
@@ -28,6 +31,9 @@ export class PeopleInHousehold implements OnInit {
   /** The ID of the household whose members should be listed. */
   public householdId = input.required<string | null>();
 
+  /**
+   * Load the list of people for the provided household ID on init.
+   */
   public async ngOnInit() {
     this.peopleInHousehold = await this.personsSvc.getPeopleInHousehold(this.householdId());
   }

--- a/apps/frontend/src/app/features/persons/ui/person-detail.html
+++ b/apps/frontend/src/app/features/persons/ui/person-detail.html
@@ -1,3 +1,4 @@
+<!-- Template for person detail view -->
 <div class="flex min-h-full flex-col bg-base-100">
   <progress class="progress w-full" [class.hidden]="!loading()"></progress>
   <form [formGroup]="form" class="mx-5 mt-10 sm:mx-10">

--- a/apps/frontend/src/app/features/persons/ui/person-detail.spec.ts
+++ b/apps/frontend/src/app/features/persons/ui/person-detail.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Basic test to ensure {@link PersonDetail} component exports exist.
+ */
 import * as exported from './person-detail';
 
 describe('person-detail', () => {

--- a/apps/frontend/src/app/features/persons/ui/person-detail.ts
+++ b/apps/frontend/src/app/features/persons/ui/person-detail.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Component for creating or updating individual person records.
+ */
 import { Component, OnInit, inject, input, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -60,6 +63,9 @@ export class PersonDetail implements OnInit {
   /** Determines if this component is in 'edit' or 'new' mode */
   public mode = input<'new' | 'edit'>('edit');
 
+  /**
+   * Initializes the component and determines edit mode via route params.
+   */
   constructor() {
     if (this.mode() === 'edit') {
       this.id = this.route.snapshot.paramMap.get('id');
@@ -153,6 +159,11 @@ export class PersonDetail implements OnInit {
       .finally(() => this.loading.set(false));
   }
 
+  /**
+   * Format an address object into a single readable string.
+   * @param address Address components to format
+   * @returns Human-readable address string
+   */
   private getFormattedAddress(address: AddressType): string {
     const parts: string[] = [];
 

--- a/apps/frontend/src/app/features/persons/ui/persons-grid.html
+++ b/apps/frontend/src/app/features/persons/ui/persons-grid.html
@@ -1,3 +1,4 @@
+<!-- Template for persons grid -->
 <pc-datagrid
   [colDefs]="col"
   [disableDelete]="false"

--- a/apps/frontend/src/app/features/persons/ui/persons-grid.spec.ts
+++ b/apps/frontend/src/app/features/persons/ui/persons-grid.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Unit tests for {@link PersonsGrid} component.
+ */
 jest.mock('@angular/core', () => {
   const actual = jest.requireActual('@angular/core');
   return {

--- a/apps/frontend/src/app/features/persons/ui/persons-grid.ts
+++ b/apps/frontend/src/app/features/persons/ui/persons-grid.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Grid component for displaying people with tagging and address features.
+ */
 import { Component, inject } from '@angular/core';
 import { UpdatePersonsObj, UpdatePersonsType } from '@common';
 import { DataGrid } from '@uxcommon/datagrid/datagrid';
@@ -115,6 +118,9 @@ export class PersonsGrid extends DataGrid<DATA_TYPE, UpdatePersonsType> {
     { field: 'notes', headerName: 'Notes', editable: true },
   ];
 
+  /**
+   * Initializes the grid and retrieves tag filter data from the route.
+   */
   constructor() {
     super();
     const route = inject(ActivatedRoute);

--- a/apps/frontend/src/app/features/tags/ui/tags-cell-renderer.spec.ts
+++ b/apps/frontend/src/app/features/tags/ui/tags-cell-renderer.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Tests for {@link TagsCellRenderer} functionality.
+ */
 import { TagsCellRenderer } from './tags-cell-renderer';
 
 jest.mock('@uxcommon/tags/tags', () => ({ Tags: class {} }), { virtual: true });

--- a/apps/frontend/src/app/features/tags/ui/tags-cell-renderer.ts
+++ b/apps/frontend/src/app/features/tags/ui/tags-cell-renderer.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Cell renderer that displays tag arrays and allows tag removal.
+ */
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { GridApi, ICellRendererParams } from 'ag-grid-community';
 import { Component } from '@angular/core';
@@ -6,7 +9,11 @@ import { Tags } from '@uxcommon/tags/tags';
 import { AbstractAPIService } from '../../../abstract-api.service';
 import { Models } from 'common/src/lib/kysely.models';
 
+/**
+ * Parameters for the {@link TagsCellRenderer} including a reference to a service.
+ */
 interface MyCellRendererParams<T extends keyof Models, U> extends ICellRendererParams {
+  /** Optional API service used for detaching tags */
   service?: AbstractAPIService<T, U>;
 }
 
@@ -28,7 +35,10 @@ export class TagsCellRenderer<T extends keyof Models, U> implements ICellRendere
 
   protected tags: string[] = [];
 
-  // gets called once before the renderer is used
+  /**
+   * Initialize the renderer with ag-Grid parameters.
+   * @param params Parameters supplied by ag-Grid
+   */
   public agInit(params: MyCellRendererParams<T, U>): void {
     this.tags = !params.value || !params.value[0] ? [] : params.value;
     this.api = params.api;
@@ -38,12 +48,20 @@ export class TagsCellRenderer<T extends keyof Models, U> implements ICellRendere
     this.colName = params.colDef?.field || '';
   }
 
-  // gets called whenever the user gets the cell to refresh
+  /**
+   * Refresh tags when grid requests an update.
+   * @param params New cell parameters
+   * @returns true to inform ag-Grid the refresh succeeded
+   */
   public refresh(params: ICellRendererParams) {
     this.tags = !params.value || !params.value[0] ? [] : params.value;
     return true;
   }
 
+  /**
+   * Detach a tag via the service and update the grid cell value.
+   * @param tag_name Tag string to remove
+   */
   public removeTag(tag_name: string) {
     this.service?.detachTag(this.rowId, tag_name);
     this.api?.getRowNode(this.rowId)?.setDataValue(this.colName, this.tags);

--- a/apps/frontend/src/app/features/tags/ui/tags-grid.spec.ts
+++ b/apps/frontend/src/app/features/tags/ui/tags-grid.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Basic existence test for {@link TagsGridComponent} exports.
+ */
 import * as exported from './tags-grid';
 
 describe('tags-grid', () => {

--- a/apps/frontend/src/app/features/tags/ui/tags-grid.ts
+++ b/apps/frontend/src/app/features/tags/ui/tags-grid.ts
@@ -1,3 +1,6 @@
+/**
+ * @file Data grid component for viewing and editing tags.
+ */
 import { Component } from '@angular/core';
 import { AddTagType } from '@common';
 import { DataGrid } from '@uxcommon/datagrid/datagrid';


### PR DESCRIPTION
## Summary
- document EmailsService and client usage with JSDoc
- expand household, person, and tag components/services with file and function comments

## Testing
- `npx nx test frontend` *(fails: container crash)*
- `npx eslint apps/frontend/src/app/features --ext .ts,.html` *(fails: Missing parameter 'recommendedConfig')*

------
https://chatgpt.com/codex/tasks/task_e_6897a6f538f88321849f6074e94ce20a