### PR TITLE
feat: stretch email list to full height

### DIFF
--- a/apps/frontend/src/app/features/emails/ui/email-list.html
+++ b/apps/frontend/src/app/features/emails/ui/email-list.html
@@ -1,12 +1,15 @@
-<section class="w-42 border-r border-gray-200">
-    <h2 class="px-4 py-2 text-xs font-semibold text-gray-600">Emails</h2>
-    <ul>
-        @for (email of emails(); track email.id) {
-            <li (click)="selectEmail(email)" [ngClass]="{ 'bg-blue-50': isSelected(email) }"
-                class="border-b border-gray-100 cursor-pointer px-4 py-2 hover:bg-blue-50">
-                <div class="truncate font-medium">{{ email.subject }}</div>
-                <div class="truncate text-xs text-gray-500">{{ email.body }}</div>
-            </li>
-        }
-    </ul>
+<section class="w-42 border-r border-gray-200 flex flex-col">
+  <h2 class="px-4 py-2 text-xs font-semibold text-gray-600">Emails</h2>
+  <ul class="flex-1 overflow-y-auto">
+    @for (email of emails(); track email.id) {
+    <li
+      (click)="selectEmail(email)"
+      [ngClass]="{ 'bg-blue-50': isSelected(email) }"
+      class="border-b border-gray-100 cursor-pointer px-4 py-2 hover:bg-blue-50"
+    >
+      <div class="truncate font-medium">{{ email.subject }}</div>
+      <div class="truncate text-xs text-gray-500">{{ email.body }}</div>
+    </li>
+    }
+  </ul>
 </section>


### PR DESCRIPTION
## Summary
- allow email list to fill vertical space and scroll

## Testing
- `npm run lint` *(fails: Missing parameter 'recommendedConfig' in FlatCompat constructor)*
- `CI=1 npx nx test frontend --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6897c118cf488321b581d0fe1c795152