### PR TITLE
feat(email): add assignment dropdown

### DIFF
--- a/apps/backend/src/app/controllers/emails.controller.ts
+++ b/apps/backend/src/app/controllers/emails.controller.ts
@@ -28,7 +28,7 @@ export class EmailsController extends BaseController<'emails', EmailRepo> {
   }
 
   /** Assign an email to a user */
-  public assignEmail(tenant_id: string, id: string, user_id: string) {
+  public assignEmail(tenant_id: string, id: string, user_id: string | null) {
     return this.update({ tenant_id, id, row: { assigned_to: user_id } as OperationDataType<'emails', 'insert'> });
   }
 

--- a/apps/backend/src/app/trpc-routers/auth.router.ts
+++ b/apps/backend/src/app/trpc-routers/auth.router.ts
@@ -19,6 +19,16 @@ function currentUser() {
 }
 
 /**
+ * Retrieve all auth users for the current tenant.
+ * Only minimal fields are returned.
+ */
+function getUsers() {
+  return authProcedure.query(({ ctx }) =>
+    controller.getAll(ctx.auth.tenant_id, { columns: ['id', 'first_name'] }),
+  );
+}
+
+/**
  * Renew access and refresh tokens.
  *
  * @input An object containing `auth_token` and `refresh_token`.
@@ -102,6 +112,7 @@ export const AuthRouter = router({
   signIn: signIn(),
   signOut: signOut(),
   currentUser: currentUser(),
+  getUsers: getUsers(),
   resetPassword: resetPassword(),
   renewAuthToken: renewAuthToken(),
   sendPasswordResetEmail: sendPasswordResetEmail(),

--- a/apps/backend/src/app/trpc-routers/emails.router.ts
+++ b/apps/backend/src/app/trpc-routers/emails.router.ts
@@ -48,7 +48,7 @@ function addComment() {
  */
 function assign() {
   return authProcedure
-    .input(z.object({ id: z.string(), user_id: z.string() }))
+    .input(z.object({ id: z.string(), user_id: z.string().nullable() }))
     .mutation(({ input, ctx }) => emails.assignEmail(ctx.auth.tenant_id, input.id, input.user_id));
 }
 

--- a/apps/frontend/src/app/auth/auth-service.ts
+++ b/apps/frontend/src/app/auth/auth-service.ts
@@ -27,6 +27,13 @@ export class AuthService extends TRPCService<'authusers'> {
   }
 
   /**
+   * Retrieve all users for the current tenant.
+   */
+  public getUsers() {
+    return this.api.auth.getUsers.query() as Promise<IAuthUser[]>;
+  }
+
+  /**
    * Initializes the auth service by fetching the current user from the backend.
    * Useful to restore session on page reload.
    */

--- a/apps/frontend/src/app/features/emails/services/emails-service.ts
+++ b/apps/frontend/src/app/features/emails/services/emails-service.ts
@@ -25,7 +25,7 @@ export class EmailsService extends TRPCService<'emails' | 'email_folders' | 'ema
    * @param user_id User ID to assign to
    * @returns Promise for the mutation
    */
-  public assign(id: string, user_id: string) {
+  public assign(id: string, user_id: string | null) {
     return this.api.emails.assign.mutate({ id, user_id });
   }
 

--- a/apps/frontend/src/app/features/emails/ui/email-details.html
+++ b/apps/frontend/src/app/features/emails/ui/email-details.html
@@ -8,9 +8,19 @@
           <h1 class="text-2xl font-semibold truncate">{{ email.subject }}</h1>
 
           <!-- Assigned to -->
-          <span class="badge badge-info badge-outline cursor-pointer"> {{ email.assigned_to || 'No Owner' }} </span>
-
-          <!-- TODO: Make it a dropdown and show all users that can be selected. We want the names of all the users for the tenant_id-->
+          <div class="dropdown">
+            <div tabindex="0" class="badge badge-info badge-outline cursor-pointer">
+              {{ getUserName(email.assigned_to) }}
+            </div>
+            <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-44 p-2 shadow">
+              @for (user of users(); track user.id) {
+              <li><a (click)="assign(user.id)">{{ user.first_name }}</a></li>
+              }
+              @if (email.assigned_to) {
+              <li><a (click)="assign(null)">Unassign</a></li>
+              }
+            </ul>
+          </div>
         </div>
       </div>
 
@@ -112,13 +122,6 @@
       <button (click)="addComment()" class="mt-2 rounded bg-blue-600 px-3 py-1 text-white">Add Comment</button>
     </div>
 
-    <div class="mt-4">
-      <h4 class="mb-2 font-semibold">Assign</h4>
-      <div class="flex items-center gap-2">
-        <input [(ngModel)]="assignTo" placeholder="Assign to user id" class="flex-1 rounded border p-2" />
-        <button (click)="assign()" class="rounded bg-green-600 px-3 py-1 text-white">Assign</button>
-      </div>
-    </div>
   </main>
   } @else {
   <div class="flex flex-1 flex-col items-center justify-center gap-3 text-gray-400 uppercase tracking-widest">


### PR DESCRIPTION
## Summary
- show assigned email owner names instead of IDs
- allow assigning/unassigning email via dropdown and fetch available users
- support nullable assignment in email API and expose user list endpoint

## Testing
- `npm run lint` *(fails: Missing parameter 'recommendedConfig' in FlatCompat constructor)*
- `npx nx test backend` *(no tests found)*
- `npx nx test frontend --runInBand` *(command crashed, no output)*

------
https://chatgpt.com/codex/tasks/task_e_6898c62ec1348321b729bd373b702add