### PR TITLE
fix: enable ag-grid dark mode

### DIFF
--- a/apps/frontend/src/app/uxcommon/datagrid/datagrid.html
+++ b/apps/frontend/src/app/uxcommon/datagrid/datagrid.html
@@ -33,7 +33,7 @@
   @if (gridVisible()) {
   <ag-grid-angular
     class="flex-1 font-light"
-    [class]="getTheme()"
+    [ngClass]="getTheme()"
     [columnDefs]="colDefsWithEdit"
     (gridReady)="onGridReady($event)"
     [gridOptions]="mergedGridOptions"

--- a/apps/frontend/src/app/uxcommon/datagrid/datagrid.ts
+++ b/apps/frontend/src/app/uxcommon/datagrid/datagrid.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, OnInit, Output, effect, inject, input, signal } from '@angular/core';
+import { NgClass } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { debounce, getAllOptionsType } from '@common';
 import { AlertService } from '@uxcommon/alerts/alert-service';
@@ -29,7 +30,7 @@ import { Models } from 'common/src/lib/kysely.models';
 
 @Component({
   selector: 'pc-datagrid',
-  imports: [AgGridModule, Icon, GridActionComponent],
+  imports: [AgGridModule, Icon, GridActionComponent, NgClass],
   templateUrl: './datagrid.html',
 })
 export class DataGrid<T extends keyof Models, U> implements OnInit {

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -1,6 +1,10 @@
 @import 'tailwindcss';
 @plugin "daisyui";
 
+@import 'ag-grid-community/styles/ag-grid.css';
+@import 'ag-grid-community/styles/ag-theme-quartz.css';
+@import 'ag-grid-community/styles/ag-theme-quartz-dark.css';
+
 @plugin "daisyui/theme" {
   name: 'light';
   default: true;


### PR DESCRIPTION
## Summary
- import AG Grid CSS themes
- use `ngClass` to swap AG Grid themes based on current mode
- add `NgClass` import for datagrid component

## Testing
- `npx nx lint frontend`
- `npx nx test frontend --runInBand` *(fails: process crashed)*

------
https://chatgpt.com/codex/tasks/task_e_6898c7872e3883218bcc17827f92d37d