### PR TITLE
refactor email details into modular components

### DIFF
--- a/apps/frontend/src/app/features/emails/ui/email-assign.html
+++ b/apps/frontend/src/app/features/emails/ui/email-assign.html
@@ -1,0 +1,15 @@
+<div class="dropdown">
+  <span class="font-light pr-2 h-auto">Assigned to: </span>
+  <div tabindex="0" class="badge badge-xs text-xs badge-info badge-outline cursor-pointer">
+    <span>{{ getUserName(email()!.assigned_to) }}</span>
+    <span><pc-icon name="chevron-down" [size]="4"></pc-icon></span>
+  </div>
+  <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-44 p-2 shadow">
+    @for (user of users(); track user.id) {
+    <li><a (click)="assign(user.id)">{{ user.first_name }}</a></li>
+    }
+    @if (email()!.assigned_to) {
+    <li><a (click)="assign(null)">Unassign</a></li>
+    }
+  </ul>
+</div>

--- a/apps/frontend/src/app/features/emails/ui/email-assign.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-assign.ts
@@ -1,0 +1,50 @@
+/**
+ * @file Component for assigning an email to a user.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, Input, WritableSignal, inject, signal } from '@angular/core';
+import { IAuthUser } from '@common';
+import { Icon } from '@uxcommon/icons/icon';
+
+import { AuthService } from '../../../auth/auth-service';
+import { EmailsService } from '../services/emails-service';
+import { EmailType } from 'common/src/lib/models';
+
+@Component({
+  selector: 'pc-email-assign',
+  standalone: true,
+  imports: [CommonModule, Icon],
+  templateUrl: 'email-assign.html',
+})
+export class EmailAssign {
+  private auth = inject(AuthService);
+  private svc: EmailsService = inject(EmailsService);
+
+  /** Email to assign */
+  @Input() public email!: WritableSignal<EmailType | null>;
+
+  /** Available users for assignment */
+  public users = signal<IAuthUser[]>([]);
+
+  constructor() {
+    this.auth.getUsers().then((u) => this.users.set(u));
+  }
+
+  /**
+   * Assign the selected email to a user or unassign if `null`.
+   */
+  public async assign(userId: string | null) {
+    const email = this.email();
+    if (!email) return;
+    await this.svc.assign(email.id, userId);
+    this.email.set({ ...email, assigned_to: userId || undefined });
+  }
+
+  /**
+   * Get the display name for an assigned user.
+   */
+  public getUserName(id?: string) {
+    if (!id) return 'Not Assigned';
+    return this.users().find((u) => u.id === id)?.first_name || 'Not Assigned';
+  }
+}

--- a/apps/frontend/src/app/features/emails/ui/email-body.html
+++ b/apps/frontend/src/app/features/emails/ui/email-body.html
@@ -1,0 +1,1 @@
+<p>{{ email()!.preview }}</p>

--- a/apps/frontend/src/app/features/emails/ui/email-body.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-body.ts
@@ -1,0 +1,17 @@
+/**
+ * @file Component displaying the body of an email.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, Input, Signal } from '@angular/core';
+import { EmailType } from 'common/src/lib/models';
+
+@Component({
+  selector: 'pc-email-body',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: 'email-body.html',
+})
+export class EmailBody {
+  /** Email to display */
+  @Input() public email!: Signal<EmailType | null>;
+}

--- a/apps/frontend/src/app/features/emails/ui/email-comments.html
+++ b/apps/frontend/src/app/features/emails/ui/email-comments.html
@@ -1,0 +1,8 @@
+<div>
+  <h4 class="mb-2 font-semibold">Comments</h4>
+  @for (comment of comments(); track comment.id) {
+  <div class="mb-2 rounded bg-gray-100 p-2">{{ comment.comment }}</div>
+  }
+  <textarea [(ngModel)]="newComment" placeholder="Add a comment" class="w-full rounded border p-2"></textarea>
+  <button (click)="addComment()" class="mt-2 rounded bg-blue-600 px-3 py-1 text-white">Add Comment</button>
+</div>

--- a/apps/frontend/src/app/features/emails/ui/email-comments.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-comments.ts
@@ -1,0 +1,39 @@
+/**
+ * @file Component handling comments for an email.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, Input, Signal, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { EmailsService } from '../services/emails-service';
+import { EmailCommentType, EmailType } from 'common/src/lib/models';
+
+@Component({
+  selector: 'pc-email-comments',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: 'email-comments.html',
+})
+export class EmailComments {
+  private svc: EmailsService = inject(EmailsService);
+
+  /** Comments for the selected email */
+  public comments = signal<Partial<EmailCommentType>[]>([]);
+
+  /** New comment text */
+  public newComment = '';
+
+  /** Email to comment on */
+  @Input() public email!: Signal<EmailType | null>;
+
+  /**
+   * Add a comment to the selected email.
+   */
+  public async addComment() {
+    const email = this.email();
+    if (!email || !this.newComment) return;
+    await this.svc.addComment(email.id, '1', this.newComment);
+    this.comments.update((c) => [...c, { comment: this.newComment }]);
+    this.newComment = '';
+  }
+}

--- a/apps/frontend/src/app/features/emails/ui/email-details.html
+++ b/apps/frontend/src/app/features/emails/ui/email-details.html
@@ -1,133 +1,14 @@
 <section class="flex-1 flex flex-col bg-white h-full">
   @if (email()) {
-  <header class="border-b border-base-200 p-4">
-    <!-- Row 1: Subject + labels (left), date + quick actions (right) -->
-    <div class="flex items-start gap-3">
-      <div class="min-w-0 flex-1">
-        <!-- Assigned to -->
-
-        <div class="dropdown">
-          <span class="font-light pr-2 h-auto">Assigned to: </span>
-          <div tabindex="0" class="badge badge-xs text-xs badge-info badge-outline cursor-pointer">
-            <span>{{ getUserName(email()!.assigned_to) }}</span>
-            <span> <pc-icon name="chevron-down" [size]="4"></pc-icon></span>
-          </div>
-          <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-44 p-2 shadow">
-            @for (user of users(); track user.id) {
-            <li><a (click)="assign(user.id)">{{ user.first_name }}</a></li>
-            } @if (email()!.assigned_to) {
-            <li><a (click)="assign(null)">Unassign</a></li>
-            }
-          </ul>
-        </div>
-        <div class="flex items-center gap-2 min-w-0">
-          <h1 class="text-2xl font-semibold truncate">{{ email()!.subject }}</h1>
-        </div>
-      </div>
-
-      <div class="flex items-center gap-1 text-sm text-base-content/70">
-        <span class="whitespace-nowrap pr-2"> {{ email()!.updated_at | date:'EEE, MMM d, h:mm a' }} </span>
-
-        <!-- Quick actions -->
-        <button class="btn btn-ghost btn-circle btn-sm" aria-label="Star">
-          <!-- star icon -->
-          <svg viewBox="0 0 24 24" class="h-5 w-5">
-            <path
-              fill="currentColor"
-              d="m12 17.27 5.18 3.05-1.64-5.81 4.46-3.86-5.86-.5L12 4l-2.14 6.15-5.86.5 4.46 3.86-1.64 5.81z"
-            />
-          </svg>
-        </button>
-        <button class="btn btn-ghost btn-circle btn-sm" aria-label="Reply">
-          <!-- reply icon -->
-          <svg viewBox="0 0 24 24" class="h-5 w-5">
-            <path fill="currentColor" d="M10 9V5l-7 7 7 7v-4.1c6 0 9.5 1.9 11 6.1-.5-5-4-10-11-10z" />
-          </svg>
-        </button>
-
-        <div class="dropdown dropdown-end">
-          <button class="btn btn-ghost btn-circle btn-sm" aria-label="More">
-            <svg viewBox="0 0 24 24" class="h-5 w-5">
-              <path
-                fill="currentColor"
-                d="M12 8a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm0 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm0 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"
-              />
-            </svg>
-          </button>
-          <ul class="menu dropdown-content bg-base-100 rounded-box z-[1] w-44 p-2 shadow">
-            <li><a>Print</a></li>
-            <li><a>Open in new</a></li>
-            <li><a>Mark as unread</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-
-    <!-- Row 2: Sender line -->
-    <div class="mt-3 flex items-center gap-3">
-      <!-- Avatar -->
-      <div class="avatar">
-        <div class="w-10 rounded-full bg-base-200">
-          <span class="flex h-full w-full items-center justify-center font-medium">
-            {{ (email()!.from_name || email()!.from_email)![0] | uppercase }}
-          </span>
-        </div>
-      </div>
-
-      <div class="min-w-0 flex-1">
-        <div class="flex items-baseline gap-2 min-w-0">
-          <span class="font-semibold truncate"> {{ email()!.from_name || email()!.from_email }} </span>
-          <span class="text-xs text-base-content/60 truncate"> &lt;{{ email()!.from_email }}&gt; </span>
-        </div>
-
-        <!-- To ... dropdown like Gmail -->
-        <div class="text-xs text-base-content/60">
-          to
-          <div class="dropdown inline-block">
-            <label tabindex="0" class="btn btn-link btn-xs no-underline align-baseline">
-              {{ email()!.to_email }}
-              <svg class="ml-1 h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
-                <path
-                  d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.94l3.71-3.71a.75.75 0 1 1 1.06 1.06l-4.24 4.24a.75.75 0 0 1-1.06 0L5.21 8.29a.75.75 0 0 1 .02-1.08z"
-                />
-              </svg>
-            </label>
-            <ul tabindex="0" class="menu menu-sm dropdown-content z-[1] mt-1 w-72 rounded-box bg-base-100 p-2 shadow">
-              <li class="menu-title text-xs">Recipients</li>
-              <li><a class="truncate">{{ email()!.to_email }}</a></li>
-              <!-- If you have CC/BCC arrays, list them here -->
-              <!-- <li><a class="truncate">cc: {{ selectedemail()!.cc?.join(', ') }}</a></li> -->
-              <!-- <li><a class="truncate">bcc: {{ selectedemail()!.bcc?.join(', ') }}</a></li> -->
-            </ul>
-          </div>
-        </div>
-      </div>
-
-      <!-- Right-side quick actions -->
-      <div class="flex items-center gap-1">
-        <button class="btn btn-ghost btn-sm" aria-label="Print">🖨️</button>
-        <button class="btn btn-ghost btn-sm" aria-label="Open in new">⤢</button>
-      </div>
-    </div>
-  </header>
-
-  <main class="flex-1 overflow-auto p-4 space-y-4">
-    <p>{{ email()!.preview }}</p>
-
-    <div>
-      <h4 class="mb-2 font-semibold">Comments</h4>
-      @for (comment of comments(); track comment.id) {
-      <div class="mb-2 rounded bg-gray-100 p-2">{{ comment.comment }}</div>
-      }
-      <textarea [(ngModel)]="newComment" placeholder="Add a comment" class="w-full rounded border p-2"></textarea>
-      <button (click)="addComment()" class="mt-2 rounded bg-blue-600 px-3 py-1 text-white">Add Comment</button>
-    </div>
-  </main>
+    <pc-email-header [email]="email"></pc-email-header>
+    <main class="flex-1 overflow-auto p-4 space-y-4">
+      <pc-email-body [email]="email"></pc-email-body>
+      <pc-email-comments [email]="email"></pc-email-comments>
+    </main>
   } @else {
-  <div class="flex flex-1 flex-col items-center justify-center gap-3 text-gray-400 uppercase tracking-widest">
-    <img class="max-w-64" src="assets/waiting.svg" />
-    <span>No emails here!</span>
-  </div>
-
+    <div class="flex flex-1 flex-col items-center justify-center gap-3 text-gray-400 uppercase tracking-widest">
+      <img class="max-w-64" src="assets/waiting.svg" />
+      <span>No emails here!</span>
+    </div>
   }
 </section>

--- a/apps/frontend/src/app/features/emails/ui/email-details.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-details.ts
@@ -1,68 +1,21 @@
 /**
- * @file Component displaying details for a selected email, including comments and assignment.
+ * @file Container component for email details view.
  */
 import { CommonModule } from '@angular/common';
-import { Component, Input, inject, signal } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { IAuthUser } from '@common';
-import { Icon } from '@uxcommon/icons/icon';
+import { Component, Input, signal } from '@angular/core';
+import { EmailType } from 'common/src/lib/models';
 
-import { AuthService } from '../../../auth/auth-service';
-import { EmailsService } from '../services/emails-service';
-import { EmailCommentType, EmailType } from 'common/src/lib/models';
+import { EmailBody } from './email-body';
+import { EmailComments } from './email-comments';
+import { EmailHeader } from './email-header';
 
 @Component({
   selector: 'pc-email-details',
   standalone: true,
-  imports: [CommonModule, FormsModule, Icon],
+  imports: [CommonModule, EmailHeader, EmailBody, EmailComments],
   templateUrl: 'email-details.html',
 })
 export class EmailDetails {
-  private auth = inject(AuthService);
-  private svc: EmailsService = inject(EmailsService);
-
-  /** Comments for the selected email */
-  public comments = signal<Partial<EmailCommentType>[]>([]);
-
   /** Email to display details for */
   @Input() public email = signal<EmailType | null>(null);
-
-  /** New comment text */
-  public newComment = '';
-
-  /** Available users for assignment */
-  public users = signal<IAuthUser[]>([]);
-
-  constructor() {
-    this.auth.getUsers().then((u) => this.users.set(u));
-  }
-
-  /**
-   * Add a comment to the selected email.
-   */
-  public async addComment() {
-    const email = this.email();
-    if (!email || !this.newComment) return;
-    await this.svc.addComment(email.id, '1', this.newComment);
-    this.comments.update((c) => [...c, { comment: this.newComment }]);
-    this.newComment = '';
-  }
-
-  /**
-   * Assign the selected email to a user or unassign if `null`.
-   */
-  public async assign(userId: string | null) {
-    const email = this.email();
-    if (!email) return;
-    await this.svc.assign(email.id, userId);
-    this.email.set({ ...email, assigned_to: userId || undefined });
-  }
-
-  /**
-   * Get the display name for an assigned user.
-   */
-  public getUserName(id?: string) {
-    if (!id) return 'Not Assigned';
-    return this.users().find((u) => u.id === id)?.first_name || 'Not Assigned';
-  }
 }

--- a/apps/frontend/src/app/features/emails/ui/email-header.html
+++ b/apps/frontend/src/app/features/emails/ui/email-header.html
@@ -1,0 +1,76 @@
+<header class="border-b border-base-200 p-4">
+  <div class="flex items-start gap-3">
+    <div class="min-w-0 flex-1">
+      <pc-email-assign [email]="email"></pc-email-assign>
+      <div class="flex items-center gap-2 min-w-0">
+        <h1 class="text-2xl font-semibold truncate">{{ email()!.subject }}</h1>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-1 text-sm text-base-content/70">
+      <span class="whitespace-nowrap pr-2"> {{ email()!.updated_at | date:'EEE, MMM d, h:mm a' }} </span>
+
+      <button class="btn btn-ghost btn-circle btn-sm" aria-label="Star">
+        <svg viewBox="0 0 24 24" class="h-5 w-5">
+          <path fill="currentColor" d="m12 17.27 5.18 3.05-1.64-5.81 4.46-3.86-5.86-.5L12 4l-2.14 6.15-5.86.5 4.46 3.86-1.64 5.81z" />
+        </svg>
+      </button>
+      <button class="btn btn-ghost btn-circle btn-sm" aria-label="Reply">
+        <svg viewBox="0 0 24 24" class="h-5 w-5">
+          <path fill="currentColor" d="M10 9V5l-7 7 7 7v-4.1c6 0 9.5 1.9 11 6.1-.5-5-4-10-11-10z" />
+        </svg>
+      </button>
+
+      <div class="dropdown dropdown-end">
+        <button class="btn btn-ghost btn-circle btn-sm" aria-label="More">
+          <svg viewBox="0 0 24 24" class="h-5 w-5">
+            <path fill="currentColor" d="M12 8a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm0 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm0 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4z" />
+          </svg>
+        </button>
+        <ul class="menu dropdown-content bg-base-100 rounded-box z-[1] w-44 p-2 shadow">
+          <li><a>Print</a></li>
+          <li><a>Open in new</a></li>
+          <li><a>Mark as unread</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-3 flex items-center gap-3">
+    <div class="avatar">
+      <div class="w-10 rounded-full bg-base-200">
+        <span class="flex h-full w-full items-center justify-center font-medium">
+          {{ (email()!.from_name || email()!.from_email)![0] | uppercase }}
+        </span>
+      </div>
+    </div>
+
+    <div class="min-w-0 flex-1">
+      <div class="flex items-baseline gap-2 min-w-0">
+        <span class="font-semibold truncate"> {{ email()!.from_name || email()!.from_email }} </span>
+        <span class="text-xs text-base-content/60 truncate"> &lt;{{ email()!.from_email }}&gt; </span>
+      </div>
+
+      <div class="text-xs text-base-content/60">
+        to
+        <div class="dropdown inline-block">
+          <label tabindex="0" class="btn btn-link btn-xs no-underline align-baseline">
+            {{ email()!.to_email }}
+            <svg class="ml-1 h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.94l3.71-3.71a.75.75 0 1 1 1.06 1.06l-4.24 4.24a.75.75 0 0 1-1.06 0L5.21 8.29a.75.75 0 0 1 .02-1.08z" />
+            </svg>
+          </label>
+          <ul tabindex="0" class="menu menu-sm dropdown-content z-[1] mt-1 w-72 rounded-box bg-base-100 p-2 shadow">
+            <li class="menu-title text-xs">Recipients</li>
+            <li><a class="truncate">{{ email()!.to_email }}</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-1">
+      <button class="btn btn-ghost btn-sm" aria-label="Print">🖨️</button>
+      <button class="btn btn-ghost btn-sm" aria-label="Open in new">⤢</button>
+    </div>
+  </div>
+</header>

--- a/apps/frontend/src/app/features/emails/ui/email-header.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-header.ts
@@ -1,0 +1,19 @@
+/**
+ * @file Component displaying header information for an email.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, Input, Signal } from '@angular/core';
+
+import { EmailAssign } from './email-assign';
+import { EmailType } from 'common/src/lib/models';
+
+@Component({
+  selector: 'pc-email-header',
+  standalone: true,
+  imports: [CommonModule, EmailAssign],
+  templateUrl: 'email-header.html',
+})
+export class EmailHeader {
+  /** Email to display */
+  @Input() public email!: Signal<EmailType | null>;
+}


### PR DESCRIPTION
## Summary
- break email details view into header, body, assignment, and comment components
- simplify pc-email-details to orchestrate new subcomponents

## Testing
- `npx nx lint frontend`
- `CI=1 npx nx test frontend`


------
https://chatgpt.com/codex/tasks/task_e_6898e63820148321a54e99825bb6cc80