### PR TITLE
Add collapsible comments section to email client

### DIFF
--- a/apps/frontend/src/app/features/emails/ui/email-comments.html
+++ b/apps/frontend/src/app/features/emails/ui/email-comments.html
@@ -1,5 +1,4 @@
 <div class="w-full p-2">
-  <h4 class="mb-2 font-semibold">Comments</h4>
   @for (comment of comments(); track comment.id) {
   <div class="mb-2 rounded bg-gray-100 p-2">{{ comment.comment }}</div>
   }

--- a/apps/frontend/src/app/features/emails/ui/email-details.html
+++ b/apps/frontend/src/app/features/emails/ui/email-details.html
@@ -2,15 +2,36 @@
   @if (email()) {
   <pc-email-header [email]="email()!"></pc-email-header>
   <main class="flex-1 h-full overflow-hidden p-4 flex flex-col gap-4">
-    <!-- 3/4 height, scrolls -->
+    @if (!commentsExpanded()) {
+    <!-- Body visible when comments are collapsed -->
     <pc-email-body
-      class="flex-[3_3_0%] min-h-0 border-double border-b-2 border-gray-200 rounded-lg bg-white"
+      class="flex-1 min-h-0 border-double border-b-2 border-gray-200 rounded-lg bg-white"
       [email]="email()!"
     >
     </pc-email-body>
+    }
 
-    <!-- 1/4 height, can scroll if long -->
-    <pc-email-comments class="flex-[1_1_0%] min-h-0 overflow-auto email-scrollbar" [email]="email"> </pc-email-comments>
+    <!-- Comments panel: either compact with status bar or expanded occupying remaining space -->
+    <div class="min-h-0 flex flex-col rounded-lg bg-white border border-gray-200 overflow-hidden">
+      <!-- Status bar -->
+      <button
+        type="button"
+        class="flex items-center justify-between px-3 py-2 text-left text-sm font-medium bg-gray-50 border-b border-gray-200 hover:bg-gray-100"
+        (click)="toggleComments()"
+        aria-expanded="{{ commentsExpanded() }}"
+        aria-controls="comments-panel"
+      >
+        <span>Comments</span>
+        <span class="ml-2 text-xs text-gray-500">@if (commentsExpanded()) { Hide } @else { Show }</span>
+      </button>
+
+      @if (commentsExpanded()) {
+      <!-- Expanded comments fill available space -->
+      <div id="comments-panel" class="flex-1 min-h-0 overflow-auto email-scrollbar">
+        <pc-email-comments [email]="email"> </pc-email-comments>
+      </div>
+      }
+    </div>
   </main>
 
   } @else {

--- a/apps/frontend/src/app/features/emails/ui/email-details.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-details.ts
@@ -2,7 +2,7 @@
  * @file Container component for email details view.
  */
 import { CommonModule } from '@angular/common';
-import { Component, input } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 
 import { EmailBody } from './email-body';
 import { EmailComments } from './email-comments';
@@ -17,4 +17,9 @@ import { EmailType } from 'common/src/lib/models';
 })
 export class EmailDetails {
   public email = input<EmailType | null>(null);
+  public commentsExpanded = signal(false);
+
+  public toggleComments(): void {
+    this.commentsExpanded.update((v) => !v);
+  }
 }


### PR DESCRIPTION
Add a collapsible 'Comments' status bar to the email details view, allowing users to toggle between the email body and an expanded comments section.

---
<a href="https://cursor.com/background-agent?bcId=bc-1102a47a-bf49-4609-99de-84f98c2b7ad7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1102a47a-bf49-4609-99de-84f98c2b7ad7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

