### PR TITLE
Move email attachments and show paperclip indicator

### DIFF
--- a/apps/frontend/src/app/features/emails/ui/email-body.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-body.spec.ts
@@ -38,11 +38,12 @@ describe('EmailBody', () => {
   beforeEach(async () => {
     const mockStore = {
       getEmailBodyById: jest.fn().mockReturnValue(() => '<p>Test email body</p>'),
+      getEmailHeaderById: jest.fn().mockReturnValue(signal<any>({ attachments: [] })),
       loadEmailWithHeaders: jest.fn().mockResolvedValue({
         body: '<p>Test email body</p>',
         header: {},
       }),
-    };
+    } as unknown as EmailsStore;
 
     await TestBed.configureTestingModule({
       declarations: [EmailBody],
@@ -76,7 +77,7 @@ describe('EmailBody', () => {
     it('should display email body from store', () => {
       fixture.detectChanges();
 
-      const bodyContent = component['getBody']();
+      const bodyContent = component['bodyHtml']();
       expect(bodyContent).toBe('<p>Test email body</p>');
     });
 
@@ -84,7 +85,7 @@ describe('EmailBody', () => {
       mockEmailsStore.getEmailBodyById.mockReturnValue(() => undefined);
       fixture.detectChanges();
 
-      const bodyContent = component['getBody']();
+      const bodyContent = component['bodyHtml']();
       expect(bodyContent).toBe('');
     });
 
@@ -93,6 +94,19 @@ describe('EmailBody', () => {
 
       const compiled = fixture.nativeElement;
       expect(compiled.innerHTML).toContain('<p>Test email body</p>');
+    });
+  });
+
+  describe('Attachments Display', () => {
+    it('should render attachments when present', () => {
+      mockEmailsStore.getEmailHeaderById.mockReturnValue(
+        signal<any>({ attachments: [{ id: 'a1', filename: 'file.txt', is_inline: false }] }),
+      );
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      const attachmentLink = compiled.querySelector('a');
+      expect(attachmentLink?.textContent).toContain('file.txt');
     });
   });
 
@@ -162,7 +176,7 @@ describe('EmailBody', () => {
       mockEmailsStore.getEmailBodyById.mockReturnValue(() => null);
       fixture.detectChanges();
 
-      const bodyContent = component['getBody']();
+      const bodyContent = component['bodyHtml']();
       expect(bodyContent).toBe('');
     });
   });

--- a/apps/frontend/src/app/features/emails/ui/email-body.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-body.ts
@@ -19,6 +19,20 @@ import type { EmailType } from 'common/src/lib/models';
       class="prose max-w-none break-words overflow-y-auto h-full p-2 email-scrollbar"
       [innerHTML]="bodyHtml() | sanitizeHtml"
     ></div>
+    @if (attachments().length > 0) {
+      <div class="mt-4 flex flex-wrap gap-2">
+        @for (att of attachments(); track att.id) {
+          <a
+            class="badge badge-outline"
+            [href]="getAttachmentUrl(att)"
+            target="_blank"
+            rel="noopener"
+          >
+            {{ att.filename }}
+          </a>
+        }
+      </div>
+    }
   `,
 })
 export class EmailBody {
@@ -33,6 +47,18 @@ export class EmailBody {
     const id = this.emailId();
     return id ? (this.store.getEmailBodyById(id)() ?? '') : '';
   });
+
+  protected readonly attachments = computed(() => {
+    const id = this.emailId();
+    if (!id) return [] as any[];
+    const header = this.store.getEmailHeaderById(id)();
+    return (header?.attachments || []).filter((a: any) => !a.is_inline);
+  });
+
+  protected getAttachmentUrl(att: any): string {
+    const id = this.emailId();
+    return id ? `/api/emails/${id}/attachments/${att.id}` : '';
+  }
 
   /** Nullable input to avoid early read before Angular sets it */
   public email = input<EmailType | null>(null);

--- a/apps/frontend/src/app/features/emails/ui/email-header.html
+++ b/apps/frontend/src/app/features/emails/ui/email-header.html
@@ -273,21 +273,6 @@
         </div>
       </div>
     </div>
-    @if (getAttachments().length > 0) {
-    <div class="mt-2 flex flex-wrap gap-2">
-      @for (att of getAttachments(); track att.id) {
-      <a
-        class="badge badge-outline"
-        [href]="getAttachmentUrl(att)"
-        target="_blank"
-        rel="noopener"
-      >
-        {{ att.filename }}
-      </a>
-      }
-    </div>
-    }
-
     <div class="flex items-center gap-1">
       <pc-swap
         class="hover:text-primary tooltip tooltip-left"

--- a/apps/frontend/src/app/features/emails/ui/email-header.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-header.ts
@@ -77,16 +77,6 @@ export class EmailHeader {
     return header?.email?.bcc_list || [];
   }
 
-  /** Get attachments for the email */
-  protected getAttachments(): any[] {
-    const header = this.headerData();
-    return (header?.attachments || []).filter((a: any) => !a.is_inline);
-  }
-
-  protected getAttachmentUrl(att: any): string {
-    const e = this.email();
-    return `/api/emails/${e.id}/attachments/${att.id}`;
-  }
 
   /** Get CC recipients from header data */
   protected getCcRecipients(): any[] {

--- a/apps/frontend/src/app/features/emails/ui/email-list.html
+++ b/apps/frontend/src/app/features/emails/ui/email-list.html
@@ -12,7 +12,12 @@
       class="border-b border-gray-100 cursor-pointer px-4 py-2 hover:bg-blue-50"
     >
       <div class="truncate text-xs text-gray-500">{{ email.from_email }}</div>
-      <div class="truncate font-medium">{{ email.subject }}</div>
+      <div class="truncate font-medium flex items-center gap-1">
+        <span class="truncate">{{ email.subject }}</span>
+        @if (email['attachment_count'] && email['attachment_count'] > 0) {
+        <pc-icon name="paper-clip" [size]="4"></pc-icon>
+        }
+      </div>
       <div class="truncate font-light text-xs text-gray-500">{{ email.preview }}</div>
     </li>
     }

--- a/apps/frontend/src/app/features/emails/ui/email-list.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-list.ts
@@ -3,6 +3,7 @@
  */
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, effect, inject, output } from '@angular/core';
+import { Icon } from '@uxcommon/icons/icon';
 
 import { EmailsStore } from '../services/store/emailstore';
 import type { EmailType } from 'common/src/lib/models';
@@ -10,7 +11,7 @@ import type { EmailType } from 'common/src/lib/models';
 @Component({
   selector: 'pc-email-list',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, Icon],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: 'email-list.html',
 })


### PR DESCRIPTION
## Summary
- move attachment links from email header to bottom of email body
- add paper-clip icon in email list when emails contain attachments
- cover attachment rendering in email body tests

## Testing
- `npx nx test frontend` *(fails: terminal crashed)*

------
https://chatgpt.com/codex/tasks/task_e_689e822d2a688321b25c647d9710afca