### PR TITLE
feat: add email drafts support

### DIFF
--- a/apps/backend/src/app/repositories/emails/email-drafts.repo.ts
+++ b/apps/backend/src/app/repositories/emails/email-drafts.repo.ts
@@ -1,0 +1,63 @@
+import { BaseRepository } from '../base.repo';
+import { OperationDataType } from 'common/src/lib/kysely.models';
+
+export class EmailDraftsRepo extends BaseRepository<'email_drafts'> {
+  constructor() {
+    super('email_drafts');
+  }
+
+  public listByUser(tenant_id: string, user_id: string) {
+    return this.getSelect()
+      .selectAll()
+      .where('tenant_id', '=', tenant_id)
+      .where('user_id', '=', user_id)
+      .orderBy('updated_at', 'desc')
+      .execute();
+  }
+
+  public getById(tenant_id: string, user_id: string, id: string) {
+    return this.getSelect()
+      .selectAll()
+      .where('tenant_id', '=', tenant_id)
+      .where('user_id', '=', user_id)
+      .where('id', '=', id)
+      .executeTakeFirst();
+  }
+
+  public async saveDraft(
+    tenant_id: string,
+    user_id: string,
+    draft: { id?: string; to_list: string[]; cc_list?: string[]; bcc_list?: string[]; subject?: string; body_html?: string; body_delta?: unknown };
+  ) {
+    const row: OperationDataType<'email_drafts', 'insert'> = {
+      tenant_id,
+      user_id,
+      to_list: draft.to_list || [],
+      cc_list: draft.cc_list || [],
+      bcc_list: draft.bcc_list || [],
+      subject: draft.subject ?? null,
+      body_html: draft.body_html ?? null,
+      body_delta: (draft.body_delta as any) ?? null,
+      meta: null,
+      thread_id: null,
+      is_locked: false,
+      createdby_id: user_id,
+      updatedby_id: user_id,
+    } as OperationDataType<'email_drafts', 'insert'>;
+
+    if (draft.id) {
+      const upd = row as OperationDataType<'email_drafts', 'update'>;
+      return this.update({ tenant_id, id: draft.id, row: upd });
+    }
+    return this.add({ row });
+  }
+
+  public async countByUser(tenant_id: string, user_id: string): Promise<number> {
+    const res = await this.getSelect()
+      .select((eb) => eb.fn.count('id').as('count'))
+      .where('tenant_id', '=', tenant_id)
+      .where('user_id', '=', user_id)
+      .executeTakeFirst();
+    return Number((res as any)?.count || 0);
+  }
+}

--- a/apps/backend/src/app/trpc-routers/emails.router.ts
+++ b/apps/backend/src/app/trpc-routers/emails.router.ts
@@ -53,6 +53,10 @@ function getEmailBody() {
   return authProcedure.input(z.string()).query(({ input, ctx }) => emails.getEmailBody(ctx.auth.tenant_id, input));
 }
 
+function getDraft() {
+  return authProcedure.input(z.string()).query(({ input, ctx }) => emails.getDraft(ctx.auth.tenant_id, ctx.auth.user_id, input));
+}
+
 /**
  * Retrieve a single email by its ID.
  * @returns The requested email record.
@@ -115,6 +119,30 @@ function setStatus() {
     .mutation(({ input, ctx }) => emails.setStatus(ctx.auth.tenant_id, input.id, input.status));
 }
 
+function saveDraft() {
+  return authProcedure
+    .input(
+      z.object({
+        id: z.string().optional(),
+        to: z.array(z.string()),
+        cc: z.array(z.string()).optional(),
+        bcc: z.array(z.string()).optional(),
+        subject: z.string().optional(),
+        html: z.string().optional(),
+      }),
+    )
+    .mutation(({ input, ctx }) =>
+      emails.saveDraft(ctx.auth.tenant_id, ctx.auth.user_id, {
+        id: input.id,
+        to_list: input.to,
+        cc_list: input.cc ?? [],
+        bcc_list: input.bcc ?? [],
+        subject: input.subject ?? undefined,
+        body_html: input.html ?? undefined,
+      }),
+    );
+}
+
 const emails = new EmailsController();
 
 /** Router exposing email-related procedures. */
@@ -123,6 +151,7 @@ export const EmailsRouter = router({
   getFoldersWithCounts: getFoldersWithCounts(),
   getEmails: getEmails(),
   getEmailBody: getEmailBody(),
+  getDraft: getDraft(),
   getEmailHeader: getEmailHeader(),
   getEmailWithHeaders: getEmailWithHeaders(),
   addComment: addComment(),
@@ -130,6 +159,7 @@ export const EmailsRouter = router({
   assign: assign(),
   setFavourite: setFavourite(),
   setStatus: setStatus(),
+  saveDraft: saveDraft(),
   hasAttachment: hasAttachment(),
   getAllAttachments: getAllAttachments(),
   getAttachmentCountByEmails: getAttachmentCountByEmails(),

--- a/apps/frontend/src/app/features/emails/services/emails-service.ts
+++ b/apps/frontend/src/app/features/emails/services/emails-service.ts
@@ -4,8 +4,8 @@
 import { Injectable } from '@angular/core';
 
 import { TRPCService } from '../../../backend-svc/trpc-service';
-import { ComposePayload } from '../ui/email-compose/email-compose';
-import { EmailType } from 'common/src/lib/models';
+import { ComposePayload, DraftPayload } from '../ui/email-compose/email-compose';
+import { EmailType, EmailDraftType } from 'common/src/lib/models';
 
 /** Service for interacting with email backend via tRPC */
 @Injectable({ providedIn: 'root' })
@@ -53,6 +53,10 @@ export class EmailsService extends TRPCService<'emails' | 'email_folders' | 'ema
 
   public getEmailBody(id: string) {
     return this.api.emails.getEmailBody.query(id);
+  }
+
+  public getDraft(id: string) {
+    return this.api.emails.getDraft.query(id) as Promise<EmailDraftType>;
   }
 
   /**
@@ -124,5 +128,9 @@ export class EmailsService extends TRPCService<'emails' | 'email_folders' | 'ema
 
   public setStatus(id: string, status: 'open' | 'closed' | 'resolved') {
     return this.api.emails.setStatus.mutate({ id, status });
+  }
+
+  public saveDraft(input: DraftPayload) {
+    return this.api.emails.saveDraft.mutate(input);
   }
 }

--- a/apps/frontend/src/app/features/emails/services/store/email-actions.store.ts
+++ b/apps/frontend/src/app/features/emails/services/store/email-actions.store.ts
@@ -4,12 +4,12 @@
  */
 import { Injectable, inject } from '@angular/core';
 
-import { ComposePayload } from '../../ui/email-compose/email-compose';
+import { ComposePayload, DraftPayload } from '../../ui/email-compose/email-compose';
 import { EmailsService } from '../emails-service';
 import { EmailCacheStore } from './email-cache.store';
 import { EmailFoldersStore } from './email-folders.store';
 import { type EmailId, EmailStateStore } from './email-state.store';
-import type { EmailType } from 'common/src/lib/models';
+import type { EmailType, EmailDraftType } from 'common/src/lib/models';
 
 @Injectable({ providedIn: 'root' })
 export class EmailActionsStore {
@@ -129,6 +129,21 @@ export class EmailActionsStore {
       this.state.replaceEmail(emailKey, prev);
       throw e;
     }
+  }
+
+  public async saveDraft(input: DraftPayload): Promise<{ id: string }> {
+    const saved = await this.svc.saveDraft(input);
+    const currentFolderId = this.folders.currentSelectedFolderId();
+    if (currentFolderId === '7') {
+      await this.folders.loadEmailsForFolder('7');
+    } else {
+      await this.folders.refreshFolderCounts();
+    }
+    return saved as { id: string };
+  }
+
+  public getDraft(id: string): Promise<EmailDraftType> {
+    return this.svc.getDraft(id);
   }
 }
 

--- a/common/src/lib/kysely.models.ts
+++ b/common/src/lib/kysely.models.ts
@@ -47,6 +47,7 @@ export interface Models {
   email_headers: EmailHeaders;
   email_recipients: EmailRecipients;
   email_attachments: EmailAttachments;
+  email_drafts: EmailDrafts;
 }
 
 export type AuthUsersType = Omit<AuthUsers, 'id'> & { id: string };
@@ -303,6 +304,19 @@ interface EmailAttachments extends RecordType {
   cid: string | null;
   is_inline: boolean;
   pos: number;
+}
+
+interface EmailDrafts extends RecordType {
+  user_id: string;
+  thread_id: string | null;
+  to_list: JsonValue | null;
+  cc_list: JsonValue | null;
+  bcc_list: JsonValue | null;
+  subject: string | null;
+  body_html: string | null;
+  body_delta: JsonValue | null;
+  meta: JsonValue | null;
+  is_locked: boolean;
 }
 
 /** Take the “S” (select-time) part if it’s a ColumnType, otherwise leave as-is */

--- a/common/src/lib/models/index.ts
+++ b/common/src/lib/models/index.ts
@@ -5,6 +5,7 @@ import type {
   EmailCommentObj,
   EmailFolderObj,
   EmailObj,
+  EmailDraftObj,
   PersonsObj,
   SettingsObj,
   UpdateHouseholdsObj,
@@ -28,6 +29,8 @@ export type EmailCommentType = z.infer<typeof EmailCommentObj>;
 export type EmailFolderType = z.infer<typeof EmailFolderObj>;
 
 export type EmailType = z.infer<typeof EmailObj>;
+
+export type EmailDraftType = z.infer<typeof EmailDraftObj>;
 
 export type PERSONINHOUSEHOLDTYPE = {
   first_name: string;

--- a/common/src/lib/schemas/index.ts
+++ b/common/src/lib/schemas/index.ts
@@ -47,6 +47,17 @@ export const EmailObj = z.object({
   status: z.enum(['open', 'closed', 'resolved']).nullable().default('open'),
 });
 
+export const EmailDraftObj = z.object({
+  id: z.string(),
+  to_list: z.array(z.string()),
+  cc_list: z.array(z.string()),
+  bcc_list: z.array(z.string()),
+  subject: z.string().optional(),
+  body_html: z.string().optional(),
+  body_delta: z.any().optional(),
+  updated_at: z.date(),
+});
+
 /**
  * The parameter for updating a person.
  * It's used with an ID in the API call that


### PR DESCRIPTION
## Summary
- allow saving and loading email drafts
- expose drafts via API and include counts
- list and edit drafts from compose form

## Testing
- `npx --yes nx test` *(fails: Could not find Nx modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a22a31d87c8321b92e3222f350101b