### PR TITLE
feat: confirm discard email drafts

### DIFF
--- a/apps/backend/src/app/controllers/emails.controller.ts
+++ b/apps/backend/src/app/controllers/emails.controller.ts
@@ -60,6 +60,10 @@ export class EmailsController extends BaseController<'emails', EmailRepo> {
     return this.draftsRepo.getById({ tenant_id, /*user_id,*/ id });
   }
 
+  public deleteDraft(tenant_id: string, _user_id: string, id: string) {
+    return this.draftsRepo.delete({ tenant_id, id });
+  }
+
   /** Return a single email and its comments */
   public async getEmailBody(tenant_id: string, id: string) {
     const email = await this.bodiesRepo.getById({ tenant_id, id });

--- a/apps/backend/src/app/trpc-routers/emails.router.ts
+++ b/apps/backend/src/app/trpc-routers/emails.router.ts
@@ -57,6 +57,12 @@ function getDraft() {
   return authProcedure.input(z.string()).query(({ input, ctx }) => emails.getDraft(ctx.auth.tenant_id, ctx.auth.user_id, input));
 }
 
+function deleteDraft() {
+  return authProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(({ input, ctx }) => emails.deleteDraft(ctx.auth.tenant_id, ctx.auth.user_id, input.id));
+}
+
 /**
  * Retrieve a single email by its ID.
  * @returns The requested email record.
@@ -156,6 +162,7 @@ export const EmailsRouter = router({
   getEmailWithHeaders: getEmailWithHeaders(),
   addComment: addComment(),
   deleteComment: deleteComment(),
+  deleteDraft: deleteDraft(),
   assign: assign(),
   setFavourite: setFavourite(),
   setStatus: setStatus(),

--- a/apps/frontend/src/app/features/emails/services/emails-service.ts
+++ b/apps/frontend/src/app/features/emails/services/emails-service.ts
@@ -133,4 +133,8 @@ export class EmailsService extends TRPCService<'emails' | 'email_folders' | 'ema
   public saveDraft(input: DraftPayload) {
     return this.api.emails.saveDraft.mutate(input);
   }
+
+  public deleteDraft(id: string) {
+    return this.api.emails.deleteDraft.mutate({ id });
+  }
 }

--- a/apps/frontend/src/app/features/emails/services/store/email-actions.store.ts
+++ b/apps/frontend/src/app/features/emails/services/store/email-actions.store.ts
@@ -80,6 +80,16 @@ export class EmailActionsStore {
     return saved as { id: string };
   }
 
+  public async deleteDraft(id: string): Promise<void> {
+    await this.svc.deleteDraft(id);
+    const currentFolderId = this.folders.currentSelectedFolderId();
+    if (currentFolderId === '7') {
+      await this.folders.loadEmailsForFolder('7');
+    } else {
+      await this.folders.refreshFolderCounts();
+    }
+  }
+
   /** Send a brand new email (with optional attachments). Refresh counts/folder after. */
   public async sendEmail(input: ComposePayload): Promise<EmailType> {
     const created = await this.svc.sendEmail(input); // implement in EmailsService (below)

--- a/apps/frontend/src/app/features/emails/ui/email-compose/email-compose.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-compose/email-compose.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComposeEmailComponent } from './email-compose';
+import { EmailActionsStore } from '../../services/store/email-actions.store';
+import { ConfirmDialogService } from '@uxcommon/shared-dialog-service';
+
+describe('ComposeEmailComponent discard', () => {
+  let component: ComposeEmailComponent;
+  let fixture: ComponentFixture<ComposeEmailComponent>;
+  let actions: jest.Mocked<EmailActionsStore>;
+  let dialogs: jest.Mocked<ConfirmDialogService>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ComposeEmailComponent],
+      providers: [
+        { provide: EmailActionsStore, useValue: { deleteDraft: jest.fn(), saveDraft: jest.fn(), sendEmail: jest.fn() } },
+        { provide: ConfirmDialogService, useValue: { confirm: jest.fn() } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ComposeEmailComponent);
+    component = fixture.componentInstance;
+    actions = TestBed.inject(EmailActionsStore) as jest.Mocked<EmailActionsStore>;
+    dialogs = TestBed.inject(ConfirmDialogService) as jest.Mocked<ConfirmDialogService>;
+  });
+
+  it('should close immediately when pristine and no draft', async () => {
+    const finished = jest.fn();
+    component.finished.subscribe(finished);
+    await component.discard();
+    expect(dialogs.confirm).not.toHaveBeenCalled();
+    expect(finished).toHaveBeenCalled();
+  });
+
+  it('should confirm when form is dirty', async () => {
+    dialogs.confirm.mockResolvedValue(true);
+    component.form.markAsDirty();
+    const finished = jest.fn();
+    component.finished.subscribe(finished);
+    await component.discard();
+    expect(dialogs.confirm).toHaveBeenCalled();
+    expect(actions.deleteDraft).not.toHaveBeenCalled();
+    expect(finished).toHaveBeenCalled();
+  });
+
+  it('should delete draft when confirmed and draft exists', async () => {
+    dialogs.confirm.mockResolvedValue(true);
+    component.draftId.set('42');
+    const finished = jest.fn();
+    component.finished.subscribe(finished);
+    await component.discard();
+    expect(dialogs.confirm).toHaveBeenCalled();
+    expect(actions.deleteDraft).toHaveBeenCalledWith('42');
+    expect(finished).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- prompt for confirmation when discarding email compose and remove draft if confirmed
- support draft deletion via actions and backend endpoints
- add unit tests for discard logic

## Testing
- `npx nx test frontend` *(fails: Could not find Nx modules)*


------
https://chatgpt.com/codex/tasks/task_e_68a2491183c883218adb3ab96c212ce9