### PR TITLE
feat: load drafts into composer

### DIFF
--- a/apps/frontend/src/app/features/emails/ui/email-client/email-client.html
+++ b/apps/frontend/src/app/features/emails/ui/email-client/email-client.html
@@ -10,7 +10,11 @@
     @if (isComposing()) {
     <div class="h-full border border-base-300 rounded-lg bg-white p-3 relative z-20">
       <!-- emits (finished) when sent/discarded -->
-      <pc-compose-email class="h-full" (finished)="closeCompose()"></pc-compose-email>
+      <pc-compose-email
+        class="h-full"
+        [draftId]="draftIdToLoad()"
+        (finished)="closeCompose()"
+      ></pc-compose-email>
     </div>
     } @else {
     <pc-email-details class="h-full" [email]="selectedEmail()"></pc-email-details>

--- a/apps/frontend/src/app/features/emails/ui/email-client/email-client.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client/email-client.ts
@@ -25,6 +25,7 @@ export class EmailClient {
   protected readonly store = inject(EmailsStore);
 
   protected isComposing = signal(false);
+  protected draftIdToLoad = signal<string | null>(null);
 
   /** Whether the email body overlay is expanded (signal from store) */
   public readonly isBodyExpanded = this.store.isBodyExpanded;
@@ -37,10 +38,12 @@ export class EmailClient {
 
   public closeCompose() {
     this.isComposing.set(false);
+    this.draftIdToLoad.set(null);
   }
 
   public newEmail() {
     this.isBodyExpanded.set(false); // ensure body overlay is closed
+    this.draftIdToLoad.set(null);
     this.isComposing.set(true);
   }
 
@@ -55,7 +58,13 @@ export class EmailClient {
 
   /** Handle email selection from child component */
   public onEmail(email: EmailType): void {
-    this.store.selectEmail(email);
+    const folderId = this.store.currentSelectedFolderId();
+    if (folderId === '7') {
+      this.draftIdToLoad.set(String(email.id));
+      this.isComposing.set(true);
+    } else {
+      this.store.selectEmail(email);
+    }
   }
 
   /** Handle folder selection from child component */
@@ -65,6 +74,7 @@ export class EmailClient {
 
   public openCompose() {
     this.isBodyExpanded.set(false); // ensure body overlay is closed
+    this.draftIdToLoad.set(null);
     this.isComposing.set(true);
   }
 

--- a/apps/frontend/src/app/features/emails/ui/email-list/email-list.html
+++ b/apps/frontend/src/app/features/emails/ui/email-list/email-list.html
@@ -12,7 +12,7 @@
       class="border-b border-gray-100 cursor-pointer px-4 py-2 hover:bg-blue-50"
     >
       <div class="truncate text-xs text-gray-500 flex gap-1">
-        <span class="truncate flex-1">{{ email.from_email }}</span>
+        <span class="truncate flex-1">{{ email.from_email || email.to_email }}</span>
 
         <!-- TODO: use the sent time -->
         <span class="flex-none">{{ email.updated_at | timeAgo:{ thresholdDays: 7, style: 'short' } }}</span>

--- a/apps/frontend/src/app/features/emails/ui/email-list/email-list.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-list/email-list.ts
@@ -31,7 +31,13 @@ export class EmailList {
       const folderId = this.store.currentSelectedFolderId();
       const emails = this.emails();
 
-      if (folderId && emails.length > 0 && !this.store.currentSelectedEmailId()) {
+      // Do not auto-select for drafts (id '7') to avoid auto-opening compose
+      if (
+        folderId &&
+        folderId !== '7' &&
+        emails.length > 0 &&
+        !this.store.currentSelectedEmailId()
+      ) {
         this.selectEmail(emails[0]);
       }
     });


### PR DESCRIPTION
## Summary
- Show `to` address when listing emails, fallback for drafts
- Open composer when selecting a draft and load its content
- Expose `draftId` input on compose component for loading drafts

## Testing
- `npx nx test frontend` *(fails: npm error canceled)*
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68a24d6ab3f883219bd3256890f1bc7d