### PR TITLE
fix: refresh draft counts and autosave

### DIFF
--- a/apps/frontend/src/app/features/emails/services/store/email-actions.store.spec.ts
+++ b/apps/frontend/src/app/features/emails/services/store/email-actions.store.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+import { EmailActionsStore } from './email-actions.store';
+import { EmailFoldersStore } from './email-folders.store';
+import { EmailsService } from '../emails-service';
+import { EmailCacheStore } from './email-cache.store';
+import { EmailStateStore } from './email-state.store';
+
+describe('EmailActionsStore deleteDraft', () => {
+  let store: EmailActionsStore;
+  let svc: { deleteDraft: jest.Mock };
+  let folders: {
+    currentSelectedFolderId: jest.Mock;
+    loadEmailsForFolder: jest.Mock;
+    refreshFolderCounts: jest.Mock;
+  };
+
+  beforeEach(() => {
+    svc = { deleteDraft: jest.fn().mockResolvedValue(undefined) };
+    folders = {
+      currentSelectedFolderId: jest.fn().mockReturnValue('7'),
+      loadEmailsForFolder: jest.fn().mockResolvedValue(undefined),
+      refreshFolderCounts: jest.fn().mockResolvedValue(undefined),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        EmailActionsStore,
+        { provide: EmailsService, useValue: svc },
+        { provide: EmailFoldersStore, useValue: folders },
+        { provide: EmailCacheStore, useValue: {} },
+        { provide: EmailStateStore, useValue: {} },
+      ],
+    });
+    store = TestBed.inject(EmailActionsStore);
+  });
+
+  it('refreshes counts and reloads drafts after deleting a draft', async () => {
+    await store.deleteDraft('42');
+    expect(svc.deleteDraft).toHaveBeenCalledWith('42');
+    expect(folders.refreshFolderCounts).toHaveBeenCalled();
+    expect(folders.loadEmailsForFolder).toHaveBeenCalledWith('7');
+  });
+});

--- a/apps/frontend/src/app/features/emails/services/store/email-actions.store.ts
+++ b/apps/frontend/src/app/features/emails/services/store/email-actions.store.ts
@@ -82,11 +82,9 @@ export class EmailActionsStore {
 
   public async deleteDraft(id: string): Promise<void> {
     await this.svc.deleteDraft(id);
-    const currentFolderId = this.folders.currentSelectedFolderId();
-    if (currentFolderId === '7') {
+    await this.folders.refreshFolderCounts();
+    if (this.folders.currentSelectedFolderId() === '7') {
       await this.folders.loadEmailsForFolder('7');
-    } else {
-      await this.folders.refreshFolderCounts();
     }
   }
 

--- a/apps/frontend/src/app/features/emails/ui/email-client/email-client.html
+++ b/apps/frontend/src/app/features/emails/ui/email-client/email-client.html
@@ -11,6 +11,7 @@
     <div class="h-full border border-base-300 rounded-lg bg-white p-3 relative z-20">
       <!-- emits (finished) when sent/discarded -->
       <pc-compose-email
+        #composer
         class="h-full"
         [draftId]="draftIdToLoad()"
         (finished)="closeCompose()"

--- a/apps/frontend/src/app/features/emails/ui/email-client/email-client.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client/email-client.spec.ts
@@ -96,14 +96,14 @@ describe('EmailClient', () => {
   });
 
   describe('Email Selection', () => {
-    it('should handle email selection from child component', () => {
-      component.onEmail(mockEmail);
+    it('should handle email selection from child component', async () => {
+      await component.onEmail(mockEmail);
 
       expect(mockEmailsStore.selectEmail).toHaveBeenCalledWith(mockEmail);
     });
 
-    it('should handle null email selection', () => {
-      component.onEmail(null as any);
+    it('should handle null email selection', async () => {
+      await component.onEmail(null as any);
 
       expect(mockEmailsStore.selectEmail).toHaveBeenCalledWith(null);
     });
@@ -183,7 +183,7 @@ describe('EmailClient', () => {
     });
 
     it('should delegate selection operations to store', () => {
-      component.onEmail(mockEmail);
+      await component.onEmail(mockEmail);
       component.onFolder(mockFolder);
 
       expect(mockEmailsStore.selectEmail).toHaveBeenCalledWith(mockEmail);
@@ -192,14 +192,27 @@ describe('EmailClient', () => {
   });
 
   describe('Error Handling', () => {
-    it('should handle undefined email gracefully', () => {
-      expect(() => component.onEmail(undefined as any)).not.toThrow();
+    it('should handle undefined email gracefully', async () => {
+      await expect(component.onEmail(undefined as any)).resolves.toBeUndefined();
       expect(mockEmailsStore.selectEmail).toHaveBeenCalledWith(undefined);
     });
 
     it('should handle undefined folder gracefully', () => {
       expect(() => component.onFolder(undefined as any)).not.toThrow();
       expect(mockEmailsStore.selectFolder).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('Draft behaviour', () => {
+    it('saves current draft and closes compose when another email is selected', async () => {
+      mockEmailsStore.currentSelectedFolderId.mockReturnValue('1');
+      component.isComposing.set(true);
+      const saveDraft = jest.fn().mockResolvedValue(undefined);
+      (component as any).composer = { saveDraft, form: { dirty: true } };
+      await component.onEmail(mockEmail);
+      expect(saveDraft).toHaveBeenCalled();
+      expect(component.isComposing()).toBe(false);
+      expect(mockEmailsStore.selectEmail).toHaveBeenCalledWith(mockEmail);
     });
   });
 });


### PR DESCRIPTION
## Summary
- refresh counts after discarding drafts and reload list when in Drafts
- autosave draft and close compose when switching emails
- add unit coverage for draft deletion and autosave behavior

## Testing
- `npx --yes nx test frontend` *(fails: Could not find Nx modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a251bde9b08321b8438963c16bd5d7