### PR TITLE
Auto-select next email and hide list when empty

### DIFF
--- a/apps/frontend/src/app/features/emails/ui/email-client/email-client.html
+++ b/apps/frontend/src/app/features/emails/ui/email-client/email-client.html
@@ -1,7 +1,7 @@
 <div class="flex text-sm bg-base-100 h-full overflow-hidden">
   <pc-email-folder-list (folderSelected)="onFolder($event)" (newEmail)="openCompose()"> </pc-email-folder-list>
 
-  @if (!isBodyExpanded()) {
+  @if (!isBodyExpanded() && emails().length) {
   <pc-email-list (emailSelected)="onEmail($event!)"></pc-email-list>
   }
 

--- a/apps/frontend/src/app/features/emails/ui/email-client/email-client.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client/email-client.ts
@@ -37,6 +37,9 @@ export class EmailClient {
   /** Currently selected folder id (signal from store) */
   public readonly selectedFolderId = this.store.currentSelectedFolderId;
 
+  /** Emails in the currently selected folder */
+  public readonly emails = this.store.emailsInSelectedFolder;
+
   public closeCompose() {
     this.isComposing.set(false);
     this.draftIdToLoad.set(null);

--- a/apps/frontend/src/app/features/emails/ui/email-list/email-list.html
+++ b/apps/frontend/src/app/features/emails/ui/email-list/email-list.html
@@ -1,9 +1,4 @@
-<section
-  class="border-r border-gray-200 flex flex-col h-full overflow-hidden"
-  [class.w-48]="emails().length"
-  [class.invisible]="!emails().length"
->
-  @if (emails().length) {
+<section class="border-r border-gray-200 flex flex-col h-full overflow-hidden w-48">
   <ul class="flex-1 overflow-y-auto min-h-0 email-scrollbar">
     @for (email of emails(); track email.id) {
     <li
@@ -33,5 +28,4 @@
     </li>
     }
   </ul>
-  }
 </section>

--- a/apps/frontend/src/app/features/emails/ui/email-list/email-list.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-list/email-list.ts
@@ -26,19 +26,28 @@ export class EmailList {
   public readonly emails = this.store.emailsInSelectedFolder;
 
   constructor() {
-    // Auto-select the first email in the folder when nothing is selected.
+    // Auto-select the first email when the current selection is removed.
     effect(() => {
       const folderId = this.store.currentSelectedFolderId();
       const emails = this.emails();
+      const selectedId = this.store.currentSelectedEmailId();
 
-      // Do not auto-select for drafts (id '7') to avoid auto-opening compose
-      if (
-        folderId &&
-        folderId !== '7' &&
-        emails.length > 0 &&
-        !this.store.currentSelectedEmailId()
-      ) {
-        this.selectEmail(emails[0]);
+      // If the list is empty, clear any existing selection and bail out.
+      if (emails.length === 0) {
+        if (selectedId) {
+          // The selected email was removed; clear selection so parent can react.
+          this.store.selectEmail(null);
+        }
+        return;
+      }
+
+      // Do not auto-select for drafts (id '7') to avoid auto-opening compose.
+      if (folderId && folderId !== '7') {
+        // If nothing is selected or the current selection no longer exists in the list,
+        // automatically select the first email.
+        if (!selectedId || !emails.some((e) => e.id === selectedId)) {
+          this.selectEmail(emails[0]);
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- Auto-select the first remaining email when the current selection disappears, or clear selection when the folder is empty
- Expose current folder emails to the client component and hide the email list when no messages remain

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx --yes nx lint frontend` *(fails: Could not find Nx modules at "/workspace/pplcrm")*
- `npx --yes nx test frontend` *(fails: Could not find Nx modules at "/workspace/pplcrm")*


------
https://chatgpt.com/codex/tasks/task_e_68a256e3cf788321af2907e3173e8edb