### PR TITLE
feat(email): add reply/forward actions

### DIFF
--- a/apps/frontend/src/app/features/emails/ui/email-client/email-client.html
+++ b/apps/frontend/src/app/features/emails/ui/email-client/email-client.html
@@ -14,11 +14,12 @@
         #composer
         class="h-full"
         [draftId]="draftIdToLoad()"
+        [initial]="composePrefill()"
         (finished)="closeCompose()"
       ></pc-compose-email>
     </div>
     } @else {
-    <pc-email-details class="h-full" [email]="selectedEmail()"></pc-email-details>
+    <pc-email-details class="h-full" [email]="selectedEmail()" (reply)="onReply($event)" (replyAll)="onReplyAll($event)" (forward)="onForward($event)"></pc-email-details>
     }
   </div>
 

--- a/apps/frontend/src/app/features/emails/ui/email-compose/email-compose.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-compose/email-compose.spec.ts
@@ -53,4 +53,10 @@ describe('ComposeEmailComponent discard', () => {
     expect(actions.deleteDraft).toHaveBeenCalledWith('42');
     expect(finished).toHaveBeenCalled();
   });
+
+  it('should patch form with initial values', () => {
+    component.initial = { to: 'a@example.com', subject: 'Hello' };
+    expect(component.form.value.to).toBe('a@example.com');
+    expect(component.form.value.subject).toBe('Hello');
+  });
 });

--- a/apps/frontend/src/app/features/emails/ui/email-compose/email-compose.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-compose/email-compose.ts
@@ -66,6 +66,17 @@ export class ComposeEmailComponent {
     }
   }
 
+  @Input() public set initial(value: ComposeInitial | null) {
+    if (!value) return;
+    this.form.patchValue({
+      to: value.to ?? '',
+      cc: value.cc ?? '',
+      bcc: value.bcc ?? '',
+      subject: value.subject ?? '',
+      html: value.html ?? '',
+    });
+  }
+
   public async delete() {
     const hasDraft = !!this.draftIdSignal();
     const isDirty = this.form.dirty;
@@ -237,4 +248,12 @@ cc: string[];
   id?: string;
   subject: string;
   to: string[];
+};
+
+export type ComposeInitial = {
+  to?: string;
+  cc?: string;
+  bcc?: string;
+  subject?: string;
+  html?: string;
 };

--- a/apps/frontend/src/app/features/emails/ui/email-details/email-details.html
+++ b/apps/frontend/src/app/features/emails/ui/email-details/email-details.html
@@ -1,6 +1,6 @@
 <section class="flex-1 flex flex-col bg-base-100 h-full overflow-hidden">
   @if (email()) {
-  <pc-email-header [email]="email()!"></pc-email-header>
+  <pc-email-header [email]="email()!" (reply)="emitReply()" (replyAll)="emitReplyAll()" (forward)="emitForward()"></pc-email-header>
   <main class="flex-1 h-full overflow-hidden p-4 flex flex-col gap-4">
     @if (!commentsExpanded() || (email() && store.isBodyExpanded())) {
     <!-- Body visible when comments are collapsed -->

--- a/apps/frontend/src/app/features/emails/ui/email-details/email-details.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-details/email-details.ts
@@ -2,7 +2,7 @@
  * @file Container component for email details view.
  */
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, effect, inject, input, signal, untracked } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Output, computed, effect, inject, input, signal, untracked } from '@angular/core';
 
 import { EmailsStore } from '../../services/store/emailstore';
 import { EmailBody } from '../email-body/email-body';
@@ -29,6 +29,10 @@ export class EmailDetails {
   });
   public commentsExpanded = signal(false);
 
+  @Output() public reply = new EventEmitter<EmailType>();
+  @Output() public replyAll = new EventEmitter<EmailType>();
+  @Output() public forward = new EventEmitter<EmailType>();
+
   constructor() {
     // Only fetch when header value is truly undefined (not when it's null/empty).
     effect(() => {
@@ -44,5 +48,20 @@ export class EmailDetails {
 
   public toggleComments(): void {
     this.commentsExpanded.update((v) => !v);
+  }
+
+  protected emitReply() {
+    const e = this.email();
+    if (e) this.reply.emit(e);
+  }
+
+  protected emitReplyAll() {
+    const e = this.email();
+    if (e) this.replyAll.emit(e);
+  }
+
+  protected emitForward() {
+    const e = this.email();
+    if (e) this.forward.emit(e);
   }
 }

--- a/apps/frontend/src/app/features/emails/ui/email-header/email-header.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-header/email-header.spec.ts
@@ -271,27 +271,24 @@ describe('EmailHeader', () => {
     });
 
     it('should handle reply action', () => {
-      spyOn(console, 'log');
-
+      const spy = jest.fn();
+      component.reply.subscribe(spy);
       component['handleReply']();
-
-      expect(console.log).toHaveBeenCalledWith('Reply to email:', '1');
+      expect(spy).toHaveBeenCalled();
     });
 
     it('should handle reply all action', () => {
-      spyOn(console, 'log');
-
+      const spy = jest.fn();
+      component.replyAll.subscribe(spy);
       component['handleReplyAll']();
-
-      expect(console.log).toHaveBeenCalledWith('Reply all to email:', '1');
+      expect(spy).toHaveBeenCalled();
     });
 
     it('should handle forward action', () => {
-      spyOn(console, 'log');
-
+      const spy = jest.fn();
+      component.forward.subscribe(spy);
       component['handleForward']();
-
-      expect(console.log).toHaveBeenCalledWith('Forward email:', '1');
+      expect(spy).toHaveBeenCalled();
     });
 
     it('should handle mark as unread action', () => {

--- a/apps/frontend/src/app/features/emails/ui/email-header/email-header.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-header/email-header.ts
@@ -2,7 +2,7 @@
  * @file Component displaying header information for an email.
  */
 import { CommonModule } from '@angular/common';
-import { Component, HostListener, computed, effect, inject, input, signal } from '@angular/core';
+import { Component, EventEmitter, HostListener, Output, computed, effect, inject, input, signal } from '@angular/core';
 import { AlertService } from '@uxcommon/alerts/alert-service';
 import { Icon } from '@uxcommon/icons/icon';
 
@@ -31,6 +31,10 @@ export class EmailHeader {
 
   /** Whether the email body is currently expanded to take over the window (except sidebar). */
   public isExpanded = this.store.isBodyExpanded;
+
+  @Output() public reply = new EventEmitter<void>();
+  @Output() public replyAll = new EventEmitter<void>();
+  @Output() public forward = new EventEmitter<void>();
 
   constructor() {
     effect(() => {
@@ -113,8 +117,7 @@ export class EmailHeader {
 
   /** Handle forward action */
   protected handleForward() {
-    console.log('Forward email:', this.email().id);
-    // TODO: Implement forward functionality
+    this.forward.emit();
   }
 
   /** Handle mark as unread action */
@@ -125,14 +128,12 @@ export class EmailHeader {
 
   /** Handle reply action */
   protected handleReply() {
-    console.log('Reply to email:', this.email().id);
-    // TODO: Implement reply functionality
+    this.reply.emit();
   }
 
   /** Handle reply all action */
   protected handleReplyAll() {
-    console.log('Reply all to email:', this.email().id);
-    // TODO: Implement reply all functionality
+    this.replyAll.emit();
   }
 
   protected markAsDoneText() {


### PR DESCRIPTION
## Summary
- support prefilled compose data for replies and forwarding
- emit reply, reply-all, and forward events from email header and details
- open composer with recipients when replying or forwarding

## Testing
- `npx -y jest -c apps/frontend/jest.config.ts apps/frontend/src/app/features/emails/ui/email-client/email-client.spec.ts apps/frontend/src/app/features/emails/ui/email-header/email-header.spec.ts apps/frontend/src/app/features/emails/ui/email-compose/email-compose.spec.ts` *(fails: Support for the experimental syntax 'decorators' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68a269a663288321b455f323761e98d6