### PR TITLE
feat: add favourites email folder

### DIFF
--- a/apps/backend/src/app/config/email-folders.config.ts
+++ b/apps/backend/src/app/config/email-folders.config.ts
@@ -69,6 +69,14 @@ export const EMAIL_FOLDERS: EmailFolderConfig[] = [
     is_virtual: true, // Virtual folder - shows assigned emails
   },
   {
+    id: '9',
+    name: 'Favourites',
+    icon: 'star',
+    sort_order: 3,
+    is_default: false,
+    is_virtual: true, // Virtual folder - shows open favourite emails
+  },
+  {
     id: '1',
     name: 'All Open',
     icon: 'document-duplicate',
@@ -81,7 +89,7 @@ export const EMAIL_FOLDERS: EmailFolderConfig[] = [
     id: '2',
     name: 'Completed',
     icon: 'document-check',
-    sort_order: 3,
+    sort_order: 5,
     is_default: false,
     is_virtual: true, // Virtual folder - shows closed/resolved emails
   },
@@ -89,7 +97,7 @@ export const EMAIL_FOLDERS: EmailFolderConfig[] = [
     id: '7',
     name: 'Drafts',
     icon: 'document',
-    sort_order: 5,
+    sort_order: 6,
     is_default: false,
     is_virtual: false, // Virtual folder - shows closed/resolved emails
   },
@@ -97,7 +105,7 @@ export const EMAIL_FOLDERS: EmailFolderConfig[] = [
     id: '3',
     name: 'Sent',
     icon: 'paper-airplane',
-    sort_order: 6,
+    sort_order: 7,
     is_default: false,
     is_virtual: false, // Regular folder - stores emails with folder_id = 3
   },
@@ -105,7 +113,7 @@ export const EMAIL_FOLDERS: EmailFolderConfig[] = [
     id: '4',
     name: 'Spam',
     icon: 'exclamation-triangle',
-    sort_order: 7,
+    sort_order: 8,
     is_default: false,
     is_virtual: false, // Regular folder - stores emails with folder_id = 4
   },
@@ -113,7 +121,7 @@ export const EMAIL_FOLDERS: EmailFolderConfig[] = [
     id: '5',
     name: 'Trash',
     icon: 'trash',
-    sort_order: 8,
+    sort_order: 9,
     is_default: false,
     is_virtual: false, // Regular folder - stores emails with folder_id = 5
   },

--- a/apps/frontend/src/app/features/emails/services/store/email-actions.store.ts
+++ b/apps/frontend/src/app/features/emails/services/store/email-actions.store.ts
@@ -105,13 +105,19 @@ export class EmailActionsStore {
     return created;
   }
 
-  /** Toggle favourite with optimistic update (no count refresh needed) */
+  /** Toggle favourite with optimistic update */
   public async toggleEmailFavoriteStatus(emailId: EmailId, isFavorite: boolean): Promise<void> {
     const key = String(emailId);
-    await this.updateProperty(key, { is_favourite: isFavorite }, () => this.svc.setFavourite(key, isFavorite), {
-      refreshFolder: false,
-      refreshCounts: false,
-    });
+    const currentFolderId = this.folders.currentSelectedFolderId();
+    await this.updateProperty(
+      key,
+      { is_favourite: isFavorite },
+      () => this.svc.setFavourite(key, isFavorite),
+      {
+        refreshFolder: currentFolderId === '9',
+        refreshCounts: true,
+      },
+    );
   }
 
   /** Update status and refresh counts (affects virtual folders) */


### PR DESCRIPTION
## Summary
- add favourites virtual folder that lists open starred emails
- refresh favourite folder and counts when toggling star

## Testing
- `npx jest apps/backend/src/app/routes/emails/emails.route.spec.ts` *(fails: Missing semicolon in TypeScript file)*
- `npm run lint` *(fails: Missing parameter 'recommendedConfig' in FlatCompat constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68a2947035188321acdfce0a1949d526