### PR TITLE
fix: normalize email before signin

### DIFF
--- a/apps/backend/src/app/controllers/auth.controller.spec.ts
+++ b/apps/backend/src/app/controllers/auth.controller.spec.ts
@@ -1,0 +1,23 @@
+import * as bcrypt from 'bcrypt';
+
+import { AuthController } from './auth.controller';
+
+describe('AuthController', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('lowercases email before lookup', async () => {
+    const controller = new AuthController();
+    const hashed = bcrypt.hashSync('password123', 1);
+    const user = { id: '1', tenant_id: 't1', password: hashed, first_name: 'Test' } as any;
+    const getUserSpy = jest
+      .spyOn(controller as any, 'getUserByEmail')
+      .mockResolvedValue(user);
+    jest
+      .spyOn(controller as any, 'createTokens')
+      .mockResolvedValue({ auth_token: 'a', refresh_token: 'r' });
+
+    await controller.signIn({ email: 'User@Example.com', password: 'password123' });
+
+    expect(getUserSpy).toHaveBeenCalledWith('user@example.com');
+  });
+});

--- a/apps/backend/src/app/controllers/auth.controller.ts
+++ b/apps/backend/src/app/controllers/auth.controller.ts
@@ -140,9 +140,9 @@ export class AuthController extends BaseController<'authusers', AuthUsersRepo> {
    * @param input Object containing `email` and `password`.
    * @returns Newly generated auth and refresh tokens.
    * @throws If credentials are invalid.
-   */
+  */
   public async signIn(input: signInInputType) {
-    const user = await this.getUserByEmail(input.email);
+    const user = await this.getUserByEmail(input.email.toLowerCase());
 
     if (!bcrypt.compareSync(input.password, user.password)) {
       throw new TRPCError({


### PR DESCRIPTION
## Summary
- normalize email to lowercase before user lookup during sign-in
- add unit test verifying sign-in accepts case-insensitive email

## Testing
- `CI=true npx nx test backend`


------
https://chatgpt.com/codex/tasks/task_e_68a37a3a03a483218a0a273e7835ba9b