### PR TITLE
feat: send jsend errors

### DIFF
--- a/apps/frontend/src/app/features/emails/services/emails-service.ts
+++ b/apps/frontend/src/app/features/emails/services/emails-service.ts
@@ -2,7 +2,7 @@
  * @file Service for interacting with the email backend via tRPC.
  */
 import { Injectable } from '@angular/core';
-import { EmailStatus } from '@common';
+import { EmailStatus, jsend, JSend } from '@common';
 
 import { TRPCService } from '../../../backend-svc/trpc-service';
 import { ComposePayload, DraftPayload } from '../ui/email-compose/email-compose';
@@ -127,8 +127,8 @@ export class EmailsService extends TRPCService<'emails' | 'email_folders' | 'ema
     input.attachments.forEach((f) => fd.append('attachments', f, f.name));
 
     const res = await fetch('/api/emails/send', { method: 'POST', body: fd });
-    if (!res.ok) throw new Error('Failed to send email');
-    return res.json() as Promise<EmailType>;
+    const json = (await res.json()) as JSend<EmailType>;
+    return jsend.unwrap(json);
   }
 
   public setFavourite(id: string, favourite: boolean) {

--- a/apps/frontend/src/app/features/emails/ui/email-compose/email-compose.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-compose/email-compose.ts
@@ -159,6 +159,8 @@ export class ComposeEmailComponent {
       };
       await this.actions.sendEmail(input);
       this.finished.emit(); // close composer
+    } catch {
+      // Error surfaced via EmailActionsStore
     } finally {
       this.sending.set(false);
     }


### PR DESCRIPTION
## Summary
- emit JSend-formatted errors in Fastify backend
- parse and surface JSend errors on email send
- display email send failures to users

## Testing
- `npx nx test backend` *(fails: terminal crashed)*
- `npx nx test frontend` *(fails: terminal crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a4e1753883219b9c4fa7adfff847