### PR TITLE
Fix email attachment count alias to prevent email fetch failures

### DIFF
--- a/apps/backend/src/app/repositories/emails/email-attachments.repo.ts
+++ b/apps/backend/src/app/repositories/emails/email-attachments.repo.ts
@@ -47,7 +47,7 @@ export class EmailAttachmentsRepo extends BaseRepository<'email_attachments'> {
   public getSelectForCountByEmails(tenant_id: string) {
     return this.getSelect()
       .select(['email_id'])
-      .select(({ fn }) => fn.count('id').as('attachment_count'))
+      .select(({ fn }) => fn.count('id').as('att_count'))
       .where('tenant_id', '=', tenant_id)
       .groupBy('email_id')
       .as('ea');


### PR DESCRIPTION
## Summary
- ensure email attachments count subquery exposes `att_count` alias

## Testing
- `npx nx lint backend`
- `npx nx test backend` *(fails: auth REST routes gets all auth users expect 200 received 500)*

------
https://chatgpt.com/codex/tasks/task_e_68a67e2bb7a08321b867a8eecda69c65