### PR TITLE
cache empty email data to prevent fetch loop

### DIFF
--- a/apps/frontend/src/app/features/emails/services/store/email-cache.store.ts
+++ b/apps/frontend/src/app/features/emails/services/store/email-cache.store.ts
@@ -81,6 +81,9 @@ export class EmailCacheStore {
     } catch (err) {
       console.error(`Failed to load email data for ${key}:`, err);
       this.alerts.showError('Failed to load email data. Please try again later.');
+      // Cache empty values to avoid endless re-fetch loops on subsequent calls
+      this.setInCache(this.emailBodiesCache, key, '');
+      this.setInCache(this.emailHeadersCache, key, null);
       return { body: '', header: null };
     } finally {
       this.unmarkLoading(key);


### PR DESCRIPTION
## Summary
- ensure missing email bodies are cached to stop repeated fetches

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ENOENT: no such file or directory, open '/workspace/pplcrm/apps/frontend/src/app/pipes/*')*


------
https://chatgpt.com/codex/tasks/task_e_68a7150da6048321af03c828d0560c09