### PR TITLE
feat(backend): add email deletion

### DIFF
--- a/apps/backend/src/app/trpc-routers/emails.router.spec.ts
+++ b/apps/backend/src/app/trpc-routers/emails.router.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Unit tests for `EmailsRouter` verifying email deletion procedures
+ * delegate to the controller and return expected results.
+ */
+import { EmailsController } from '../controllers/emails.controller';
+import { EmailsRouter } from './emails.router';
+
+/** Test suite for email-related router procedures. */
+describe('EmailsRouter', () => {
+  const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
+  let caller: ReturnType<typeof EmailsRouter.createCaller>;
+
+  /** Mock controller methods and create router caller. */
+  beforeAll(() => {
+    jest.spyOn(EmailsController.prototype, 'delete').mockResolvedValue(true as any);
+    jest.spyOn(EmailsController.prototype, 'deleteMany').mockResolvedValue(true as any);
+    caller = EmailsRouter.createCaller(ctx);
+  });
+
+  /** Restore mocked methods after tests. */
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** Tests deleting a single email. */
+  it('deletes an email', async () => {
+    await expect(caller.delete('1')).resolves.toBeTruthy();
+  });
+
+  /** Tests deleting multiple emails. */
+  it('deletes multiple emails', async () => {
+    await expect(caller.deleteMany(['1', '2'])).resolves.toBeTruthy();
+  });
+});

--- a/apps/backend/src/app/trpc-routers/emails.router.ts
+++ b/apps/backend/src/app/trpc-routers/emails.router.ts
@@ -42,6 +42,18 @@ function deleteDraft() {
     .mutation(wrapTrpc(({ input, ctx }) => emails.deleteDraft(ctx.auth.tenant_id, ctx.auth.user_id, input.id)));
 }
 
+function deleteEmail() {
+  return authProcedure
+    .input(z.string())
+    .mutation(wrapTrpc(({ input, ctx }) => emails.delete(ctx.auth.tenant_id, input)));
+}
+
+function deleteEmails() {
+  return authProcedure
+    .input(z.array(z.string()))
+    .mutation(wrapTrpc(({ input, ctx }) => emails.deleteMany(ctx.auth.tenant_id, input)));
+}
+
 function getAllAttachments() {
   return authProcedure
     .input(z.object({ email_id: z.string(), options: z.object({ includeInline: z.boolean() }).optional() }))
@@ -179,6 +191,8 @@ export const EmailsRouter = router({
   addComment: addComment(),
   deleteComment: deleteComment(),
   deleteDraft: deleteDraft(),
+  delete: deleteEmail(),
+  deleteMany: deleteEmails(),
   assign: assign(),
   setFavourite: setFavourite(),
   setStatus: setStatus(),


### PR DESCRIPTION
## Summary
- add email deletion endpoints
- cover email deletion with unit tests

## Testing
- `npx nx test backend` *(fails: terminal crashed)*
- `npx jest -c apps/backend/jest.config.ts apps/backend/src/app/trpc-routers/emails.router.spec.ts`
- `npx eslint apps/backend/src/app/trpc-routers/emails.router.ts apps/backend/src/app/trpc-routers/emails.router.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a783ad090c832181238bea1925fee8