### PR TITLE
fix: auto-select first draft email

### DIFF
--- a/apps/frontend/src/app/features/emails/ui/email-body/email-body.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-body/email-body.spec.ts
@@ -11,7 +11,7 @@ import { EmailType } from 'common/src/lib/models/models';
 
 // Mock sanitize pipe
 @Component({
-  selector: 'mock-sanitize-pipe',
+  selector: 'pc-mock-sanitize-pipe',
   template: '{{ value }}',
 })
 class MockSanitizePipe {

--- a/apps/frontend/src/app/features/emails/ui/email-list/email-list.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-list/email-list.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { EmailList } from './email-list';
+import { EmailsStore } from '../../services/store/emailstore';
+import { ALL_FOLDERS } from 'common/src/lib/emails';
+import type { EmailType } from 'common/src/lib/models';
+
+describe('EmailList', () => {
+  let component: EmailList;
+  let mockStore: any;
+  let emailsSignal = signal<EmailType[]>([]);
+  let selectedIdSignal = signal<string | null>(null);
+  let folderIdSignal = signal<string | null>(ALL_FOLDERS.DRAFTS);
+
+  beforeEach(() => {
+    emailsSignal = signal<EmailType[]>([]);
+    selectedIdSignal = signal<string | null>(null);
+    folderIdSignal = signal<string | null>(ALL_FOLDERS.DRAFTS);
+
+    mockStore = {
+      emailsInSelectedFolder: emailsSignal,
+      currentSelectedEmailId: selectedIdSignal,
+      currentSelectedFolderId: folderIdSignal,
+      selectEmail: jest.fn(),
+    } as Partial<EmailsStore>;
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: EmailsStore, useValue: mockStore }],
+    });
+
+    component = TestBed.runInInjectionContext(() => new EmailList());
+  });
+
+  it('auto-selects the first email in drafts folder', () => {
+    const draftEmail: EmailType = {
+      id: '1',
+      folder_id: ALL_FOLDERS.DRAFTS,
+      updated_at: new Date(),
+      is_favourite: false,
+      attachment_count: 0,
+      has_attachment: false,
+      status: 'open',
+    };
+
+    let emitted: EmailType | undefined;
+    component.emailSelected.subscribe((e) => (emitted = e));
+
+    emailsSignal.set([draftEmail]);
+
+    expect(emitted).toEqual(draftEmail);
+  });
+});

--- a/apps/frontend/src/app/features/emails/ui/email-list/email-list.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-list/email-list.ts
@@ -7,7 +7,6 @@ import { Icon } from '@uxcommon/icons/icon';
 import { TimeAgoPipe } from '@uxcommon/timeago.pipe';
 
 import { EmailsStore } from '../../services/store/emailstore';
-import { ALL_FOLDERS } from 'common/src/lib/emails';
 import type { EmailType } from 'common/src/lib/models';
 
 @Component({
@@ -42,8 +41,7 @@ export class EmailList {
         return;
       }
 
-      // Do not auto-select for drafts (id '7') to avoid auto-opening compose.
-      if (folderId && folderId !== ALL_FOLDERS.DRAFTS) {
+      if (folderId) {
         // If nothing is selected or the current selection no longer exists in the list,
         // automatically select the first email.
         if (!selectedId || !emails.some((e) => e.id === selectedId)) {


### PR DESCRIPTION
## Summary
- auto-select first email in all folders, including Drafts
- add unit test to verify draft auto-selection
- align mock sanitize pipe selector with project prefix

## Testing
- `npx nx lint frontend`
- `npx nx test frontend` *(fails: Cannot find module '../email-client' et al.)*

------
https://chatgpt.com/codex/tasks/task_e_68abc09d24948321ac4ac5891dc72cfd