### PR TITLE
Allow saving empty email drafts

### DIFF
--- a/apps/backend/src/app/controllers/emails.controller.spec.ts
+++ b/apps/backend/src/app/controllers/emails.controller.spec.ts
@@ -1,0 +1,27 @@
+import { EmailsController } from './emails.controller';
+import { EmailDraftsRepo } from '../repositories/emails/email-drafts.repo';
+
+describe('EmailsController', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('saves a draft without recipients', async () => {
+    const controller = new EmailsController();
+    const spy = jest
+      .spyOn(EmailDraftsRepo.prototype, 'saveDraft')
+      .mockResolvedValue({ id: '1' } as any);
+
+    await expect(
+      controller.saveDraft('t1', 'u1', {
+        to_list: [],
+        cc_list: [],
+        bcc_list: [],
+      }),
+    ).resolves.toEqual({ id: '1' });
+
+    expect(spy).toHaveBeenCalledWith('t1', 'u1', {
+      to_list: [],
+      cc_list: [],
+      bcc_list: [],
+    });
+  });
+});

--- a/apps/backend/src/app/controllers/emails.controller.ts
+++ b/apps/backend/src/app/controllers/emails.controller.ts
@@ -259,9 +259,6 @@ export class EmailsController extends BaseController<'emails', EmailRepo> {
       body_html?: string;
     },
   ) {
-    if (!Array.isArray(draft.to_list) || draft.to_list.length === 0) {
-      throw new BadRequestError('Draft must include at least one recipient');
-    }
     try {
       const saved = await this.draftsRepo.saveDraft(tenant_id, user_id, draft);
       if (!saved) throw new InternalError('Failed to save draft');

--- a/apps/backend/src/app/routes/auth/auth.route.spec.ts
+++ b/apps/backend/src/app/routes/auth/auth.route.spec.ts
@@ -18,6 +18,9 @@ describe('auth REST routes', () => {
 
     const routes = (await import('./auth.route')).default;
     app = Fastify();
+    app.decorateReply('jsendSuccess', function (this: any, payload: any) {
+      this.send({ status: 'success', data: payload });
+    });
     app.register(routes, { prefix: '/auth' });
     await app.ready();
   });
@@ -30,7 +33,7 @@ describe('auth REST routes', () => {
   it('gets all auth users', async () => {
     const res = await app.inject({ method: 'GET', url: '/auth', headers: { 'tenant-id': tenantId } });
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual(rows);
+    expect(JSON.parse(res.body)).toEqual({ status: 'success', data: rows });
   });
 
   it('gets an auth user by id', async () => {


### PR DESCRIPTION
## Summary
- remove recipient requirement when saving email drafts
- test draft saving without recipients
- adjust auth route tests to mock jsend responses

## Testing
- `npx nx test backend`


------
https://chatgpt.com/codex/tasks/task_e_68ac87b0ff8c83219c5fde126812c5b3