### PR TITLE
fix draft compose state handling

### DIFF
--- a/apps/frontend/src/app/features/emails/ui/email-compose/email-compose.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-compose/email-compose.ts
@@ -119,6 +119,7 @@ export class ComposeEmailComponent {
       html: d.body_html || '',
     });
     this.draftIdSignal.set(d.id);
+    this.form.markAsPristine();
   }
 
   public onDragLeave(e: DragEvent) {


### PR DESCRIPTION
## Summary
- mark compose form pristine after loading a draft to avoid unnecessary save calls

## Testing
- `npm run lint` *(fails: ENOENT no such file or directory '/workspace/pplcrm/apps/frontend/src/app/pipes/*')*
- `npx jest apps/frontend/src/app/features/emails/ui/email-compose/email-compose.spec.ts` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8b5ba5f08321a66873dc0d120f09