### PR TITLE
fix: highlight selected draft emails

### DIFF
--- a/apps/frontend/src/app/features/emails/ui/email-client/email-client.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client/email-client.spec.ts
@@ -7,6 +7,7 @@ import { Component, EventEmitter, Input, Output, signal } from '@angular/core';
 import { EmailClient } from '../email-client';
 import { EmailsStore } from '../../services/store/emailstore';
 import { EmailType, EmailFolderType } from 'common/src/lib/models/models';
+import { ALL_FOLDERS } from 'common/src/lib/emails';
 
 // Mock child components
 @Component({
@@ -217,6 +218,14 @@ describe('EmailClient', () => {
       expect(saveDraft).toHaveBeenCalled();
       expect(component.isComposing()).toBe(false);
       expect(mockEmailsStore.selectEmail).toHaveBeenCalledWith(mockEmail);
+    });
+
+    it('selects draft email and opens composer when draft folder is active', async () => {
+      mockEmailsStore.currentSelectedFolderId.mockReturnValue(ALL_FOLDERS.DRAFTS);
+      await component.onEmail(mockEmail);
+      expect(mockEmailsStore.selectEmail).toHaveBeenCalledWith(mockEmail);
+      expect(component.isComposing()).toBe(true);
+      expect(component['draftIdToLoad']()).toBe(String(mockEmail.id));
     });
   });
 

--- a/apps/frontend/src/app/features/emails/ui/email-client/email-client.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-client/email-client.ts
@@ -63,7 +63,7 @@ export class EmailClient {
   }
 
   /** Handle email selection from child component */
-  public async onEmail(email: EmailType): Promise<void> {
+  public async onEmail(email: EmailType | null): Promise<void> {
     const folderId = this.store.currentSelectedFolderId();
     if (this.isComposing()) {
       try {
@@ -75,11 +75,14 @@ export class EmailClient {
       }
       this.closeCompose();
     }
-    if (folderId === ALL_FOLDERS.DRAFTS) {
+
+    // Always update the store selection so the list can reflect it
+    this.store.selectEmail(email);
+
+    // In the drafts folder, also open the composer for the selected draft
+    if (folderId === ALL_FOLDERS.DRAFTS && email) {
       this.draftIdToLoad.set(String(email.id));
       this.isComposing.set(true);
-    } else {
-      this.store.selectEmail(email);
     }
   }
 

--- a/apps/frontend/src/app/features/emails/ui/email-list/email-list.spec.ts
+++ b/apps/frontend/src/app/features/emails/ui/email-list/email-list.spec.ts
@@ -31,7 +31,7 @@ describe('EmailList', () => {
     component = TestBed.runInInjectionContext(() => new EmailList());
   });
 
-  it('auto-selects the first email in drafts folder', () => {
+  it('auto-selects the first email in drafts folder', async () => {
     const draftEmail: EmailType = {
       id: '1',
       folder_id: ALL_FOLDERS.DRAFTS,
@@ -46,6 +46,9 @@ describe('EmailList', () => {
     component.emailSelected.subscribe((e) => (emitted = e));
 
     emailsSignal.set([draftEmail]);
+
+    // Allow the signal effect to run before asserting
+    await new Promise((resolve) => setTimeout(resolve));
 
     expect(emitted).toEqual(draftEmail);
   });


### PR DESCRIPTION
## Summary
- highlight selected draft emails by updating selection and opening composer
- add tests for draft selection behaviour
- ensure email list test waits for reactive updates

## Testing
- `npm run lint`
- `npx jest -c apps/frontend/jest.config.ts` *(fails: module and type errors in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8defb99483218e73e07a66ceb69c