### PR TITLE
refactor environment injection token

### DIFF
--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -1,12 +1,11 @@
 import {
   ApplicationConfig,
   ErrorHandler,
-  Environment,
   inject,
   provideAppInitializer,
-  provideEnvironment,
   provideZonelessChangeDetection,
 } from '@angular/core';
+import { ENVIRONMENT } from './environment-token';
 import { RouteReuseStrategy, provideRouter } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { Loader } from '@googlemaps/js-api-loader';
@@ -55,14 +54,14 @@ export function tokenGetter() {
  */
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideEnvironment(environment),
+    { provide: ENVIRONMENT, useValue: environment },
     /**
      * Provides Google Maps API Loader globally with the 'places' library.
      */
     {
       provide: Loader,
       useFactory: () => {
-        const env = inject(Environment);
+        const env = inject(ENVIRONMENT);
         return new Loader({
           apiKey: env.googleMapsApiKey,
           libraries: ['places'],

--- a/apps/frontend/src/app/environment-token.ts
+++ b/apps/frontend/src/app/environment-token.ts
@@ -1,0 +1,4 @@
+import { InjectionToken } from '@angular/core';
+import { environment } from '../environments/environment';
+export const ENVIRONMENT = new InjectionToken<typeof environment>('ENVIRONMENT', { factory: () => environment });
+


### PR DESCRIPTION
## Summary
- replace Environment/provideEnvironment with ENVIRONMENT injection token
- use ENVIRONMENT when creating Google Maps Loader

## Testing
- `npx nx lint frontend`
- `npx nx test frontend --runInBand --watch=false` *(fails: 45 failed, 32 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1dfff5b88321bc2dd8e7c7ce38f9