### PR TITLE
refactor: use browser env for maps api key

### DIFF
--- a/apps/frontend/src/environments/environment.prod.ts
+++ b/apps/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: 'https://pplcrm.example.com',
-  googleMapsApiKey: process.env['NX_GOOGLE_MAPS_API_KEY'] ?? '',
+  googleMapsApiKey: import.meta.env['NX_GOOGLE_MAPS_API_KEY'] ?? '',
 };

--- a/apps/frontend/src/environments/environment.ts
+++ b/apps/frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:3000',
-  googleMapsApiKey: process.env['NX_GOOGLE_MAPS_API_KEY'] ?? '',
+  googleMapsApiKey: import.meta.env['NX_GOOGLE_MAPS_API_KEY'] ?? '',
 };

--- a/apps/frontend/src/import-meta.d.ts
+++ b/apps/frontend/src/import-meta.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly [key: string]: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- use `import.meta.env` in frontend environment config
- declare ambient types for `import.meta.env`

## Testing
- `npx nx lint frontend --output-style=static`

------
https://chatgpt.com/codex/tasks/task_e_68ad2669fce883219fd46fb83167c1b2