### PR TITLE
refactor: split dashboard routes and lazy load

### DIFF
--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -1,12 +1,5 @@
-import { Route } from '@angular/router';
-import { EmailClient } from '@experiences/emails/ui/email-client/email-client';
-import { HouseholdDetail } from '@experiences/households/ui/household-detail';
-import { HouseholdsGrid } from '@experiences/households/ui/households-grid';
-import { PersonDetail } from '@experiences/persons/ui/person-detail';
-import { PersonsGrid } from '@experiences/persons/ui/persons-grid';
-import { TagsGridComponent } from '@experiences/tags/ui/tags-grid';
-import { NotFound } from '@uxcommon/not-found/not-found';
-import { AddTag } from '@uxcommon/tags/add-tag';
+import type { Routes } from '@angular/router';
+import { NotFound } from './uxcommon/not-found/not-found';
 
 import { authGuard } from './auth/auth-guard';
 import { loginGuard } from './auth/login/login-guard';
@@ -14,15 +7,13 @@ import { NewPasswordPage } from './auth/new-password-page/new-password-page';
 import { ResetPasswordPage } from './auth/reset-password-page/reset-password-page';
 import { SignInPage } from './auth/signin-page/signin-page';
 import { SignUpPage } from './auth/signup-page/signup-page';
-import { Dashboard } from './layout/dashboards/dashboard';
-import { Summary } from './summary/summary';
 
 /**
  * The main route configuration for the application.
  *
  * Includes routing for authentication, dashboard, and fallback routes.
  */
-export const appRoutes: Route[] = [
+export const appRoutes: Routes = [
   /**
    * Default redirect to summary page inside the dashboard.
    */
@@ -41,117 +32,11 @@ export const appRoutes: Route[] = [
    */
   {
     path: '',
-    component: Dashboard,
     canActivate: [authGuard],
-    children: [
-      {
-        path: '',
-        redirectTo: 'summary',
-        pathMatch: 'full',
-      },
-      /**
-       * Dashboard summary page.
-       */
-      {
-        path: 'summary',
-        component: Summary,
-      },
-
-      /**
-       * People management routes.
-       */
-      {
-        path: 'people',
-        children: [
-          {
-            path: '',
-            component: PersonsGrid,
-            data: { shouldReuse: true, key: 'persongridroot' },
-          },
-          {
-            path: 'add',
-            component: PersonDetail,
-          },
-          {
-            path: ':id',
-            component: PersonDetail,
-          },
-        ],
-      },
-
-      /**
-       * Household management routes.
-       */
-      {
-        path: 'households',
-        children: [
-          {
-            path: '',
-            component: HouseholdsGrid,
-            data: { shouldReuse: true, key: 'householdsgridroot' },
-          },
-          {
-            path: 'add',
-            component: HouseholdDetail,
-          },
-          {
-            path: ':id',
-            component: HouseholdDetail,
-          },
-        ],
-      },
-
-      /**
-       * Tag management routes.
-       */
-      {
-        path: 'tags',
-        children: [
-          {
-            path: '',
-            component: TagsGridComponent,
-            data: { shouldReuse: true, key: 'tagsgridroot' },
-          },
-          {
-            path: 'add',
-            component: AddTag,
-          },
-        ],
-      },
-
-      /**
-       * Volunteer management route.
-       */
-      {
-        path: 'volunteers',
-        children: [
-          {
-            path: '',
-            component: PersonsGrid,
-            data: { shouldReuse: true, key: 'volunteersgridroot', tags: ['volunteer'] },
-          },
-        ],
-      },
-
-      /**
-       * Donor management route.
-       */
-      {
-        path: 'donors',
-        children: [
-          {
-            path: '',
-            component: PersonsGrid,
-            data: { shouldReuse: true, key: 'donorsgridroot', tags: ['donor'] },
-          },
-        ],
-      },
-
-      {
-        path: 'emails',
-        component: EmailClient,
-      },
-    ],
+    component: () =>
+      import('./layout/dashboards/dashboard').then((m) => m.Dashboard),
+    children: () =>
+      import('./dashboard.routes').then((m) => m.dashboardRoutes),
   },
 
   /**

--- a/apps/frontend/src/app/dashboard.routes.ts
+++ b/apps/frontend/src/app/dashboard.routes.ts
@@ -1,0 +1,112 @@
+import type { Routes } from '@angular/router';
+
+export const dashboardRoutes: Routes = [
+  {
+    path: '',
+    redirectTo: 'summary',
+    pathMatch: 'full',
+  },
+  {
+    path: 'summary',
+    component: () => import('./summary/summary').then((m) => m.Summary),
+  },
+  {
+    path: 'people',
+    children: [
+      {
+        path: '',
+        component: () =>
+          import('./experiences/persons/ui/persons-grid').then((m) => m.PersonsGrid),
+        data: { shouldReuse: true, key: 'persongridroot' },
+      },
+      {
+        path: 'add',
+        component: () =>
+          import('./experiences/persons/ui/person-detail').then(
+            (m) => m.PersonDetail
+          ),
+      },
+      {
+        path: ':id',
+        component: () =>
+          import('./experiences/persons/ui/person-detail').then(
+            (m) => m.PersonDetail
+          ),
+      },
+    ],
+  },
+  {
+    path: 'households',
+    children: [
+      {
+        path: '',
+        component: () =>
+          import('./experiences/households/ui/households-grid').then(
+            (m) => m.HouseholdsGrid
+          ),
+        data: { shouldReuse: true, key: 'householdsgridroot' },
+      },
+      {
+        path: 'add',
+        component: () =>
+          import('./experiences/households/ui/household-detail').then(
+            (m) => m.HouseholdDetail
+          ),
+      },
+      {
+        path: ':id',
+        component: () =>
+          import('./experiences/households/ui/household-detail').then(
+            (m) => m.HouseholdDetail
+          ),
+      },
+    ],
+  },
+  {
+    path: 'tags',
+    children: [
+      {
+        path: '',
+        component: () =>
+          import('./experiences/tags/ui/tags-grid').then(
+            (m) => m.TagsGridComponent
+          ),
+        data: { shouldReuse: true, key: 'tagsgridroot' },
+      },
+      {
+        path: 'add',
+        component: () =>
+          import('./uxcommon/tags/add-tag').then((m) => m.AddTag),
+      },
+    ],
+  },
+  {
+    path: 'volunteers',
+    children: [
+      {
+        path: '',
+        component: () =>
+          import('./experiences/persons/ui/persons-grid').then((m) => m.PersonsGrid),
+        data: { shouldReuse: true, key: 'volunteersgridroot', tags: ['volunteer'] },
+      },
+    ],
+  },
+  {
+    path: 'donors',
+    children: [
+      {
+        path: '',
+        component: () =>
+          import('./experiences/persons/ui/persons-grid').then((m) => m.PersonsGrid),
+        data: { shouldReuse: true, key: 'donorsgridroot', tags: ['donor'] },
+      },
+    ],
+  },
+  {
+    path: 'emails',
+    component: () =>
+      import('./experiences/emails/ui/email-client/email-client').then(
+        (m) => m.EmailClient
+      ),
+  },
+];


### PR DESCRIPTION
## Summary
- move dashboard child routes to new `dashboard.routes.ts`
- lazy load large feature components for people, households, tags, and more
- update route configuration to Angular 20 `component`/`children` syntax

## Testing
- `npx jest apps/frontend/src/app/app.routes.spec.ts --runInBand` *(fails: Cannot use import statement outside a module)*
- `npx eslint apps/frontend/src/app/app.routes.ts apps/frontend/src/app/dashboard.routes.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ad9d814c4c8321a606e98e53d63f5f