### PR TITLE
Fix backend tests for getOneById rename

### DIFF
--- a/apps/backend/src/app/modules/auth/routes/auth.route.spec.ts
+++ b/apps/backend/src/app/modules/auth/routes/auth.route.spec.ts
@@ -12,7 +12,7 @@ describe('auth REST routes', () => {
   beforeAll(async () => {
     jest.spyOn(AuthController.prototype, 'getAll').mockResolvedValue(rows as any);
     jest
-      .spyOn(AuthController.prototype, 'getById')
+      .spyOn(AuthController.prototype, 'getOneById')
       .mockImplementation(async ({ id }) => rows.find((r) => r.id === id) as any);
     jest.spyOn(AuthController.prototype, 'getCount').mockResolvedValue(rows.length);
 

--- a/apps/backend/src/app/modules/households/routes/households.route.spec.ts
+++ b/apps/backend/src/app/modules/households/routes/households.route.spec.ts
@@ -12,7 +12,7 @@ describe('households REST routes', () => {
   beforeAll(async () => {
     jest.spyOn(HouseholdsController.prototype, 'getAll').mockResolvedValue(rows as any);
     jest
-      .spyOn(HouseholdsController.prototype, 'getById')
+      .spyOn(HouseholdsController.prototype, 'getOneById')
       .mockImplementation(async ({ id }) => rows.find((r) => r.id === id) as any);
     jest.spyOn(HouseholdsController.prototype, 'getCount').mockResolvedValue(rows.length);
 

--- a/apps/backend/src/app/modules/households/trpc.router.spec.ts
+++ b/apps/backend/src/app/modules/households/trpc.router.spec.ts
@@ -20,7 +20,7 @@ describe('HouseholdsRouter', () => {
     jest.spyOn(HouseholdsController.prototype, 'detachTag').mockResolvedValue(undefined as any);
     jest.spyOn(HouseholdsController.prototype, 'getAll').mockResolvedValue([{ id: '1' }] as any);
     jest.spyOn(HouseholdsController.prototype, 'getAllWithPeopleCount').mockResolvedValue({ rows: [], count: 0 } as any);
-    jest.spyOn(HouseholdsController.prototype, 'getById').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(HouseholdsController.prototype, 'getOneById').mockResolvedValue({ id: '1' } as any);
     jest.spyOn(HouseholdsController.prototype, 'getDistinctTags').mockResolvedValue(['a']);
     jest.spyOn(HouseholdsController.prototype, 'getTags').mockResolvedValue(['a']);
     jest.spyOn(HouseholdsController.prototype, 'update').mockResolvedValue({ id: '1' } as any);

--- a/apps/backend/src/app/modules/persons/routes/persons.route.spec.ts
+++ b/apps/backend/src/app/modules/persons/routes/persons.route.spec.ts
@@ -12,7 +12,7 @@ describe('persons REST routes', () => {
   beforeAll(async () => {
     jest.spyOn(PersonsController.prototype, 'getAll').mockResolvedValue(rows as any);
     jest
-      .spyOn(PersonsController.prototype, 'getById')
+      .spyOn(PersonsController.prototype, 'getOneById')
       .mockImplementation(async ({ id }) => rows.find((r) => r.id === id) as any);
     jest.spyOn(PersonsController.prototype, 'getCount').mockResolvedValue(rows.length);
 

--- a/apps/backend/src/app/modules/tags/trpc.router.spec.ts
+++ b/apps/backend/src/app/modules/tags/trpc.router.spec.ts
@@ -16,7 +16,7 @@ describe('TagsRouter', () => {
     jest.spyOn(TagsController.prototype, 'getCount').mockResolvedValue(1);
     jest.spyOn(TagsController.prototype, 'getAll').mockResolvedValue([{ id: '1' }] as any);
     jest.spyOn(TagsController.prototype, 'updateTag').mockResolvedValue({ id: '1' } as any);
-    jest.spyOn(TagsController.prototype, 'getById').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(TagsController.prototype, 'getOneById').mockResolvedValue({ id: '1' } as any);
     jest.spyOn(TagsController.prototype, 'delete').mockResolvedValue(true as any);
     jest.spyOn(TagsController.prototype, 'deleteMany').mockResolvedValue(true as any);
     jest.spyOn(TagsController.prototype, 'findByName').mockResolvedValue([{ id: '1' }]);


### PR DESCRIPTION
## Summary
- update backend route and tRPC tests to spy on `getOneById` instead of removed `getById`
- ensure backend test suite passes again

## Testing
- `npx jest -c apps/backend/jest.config.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68ada56ab1bc8321a9b4c4aad57da38f