### PR TITLE
Refactor auth pages with shared layout and password components

### DIFF
--- a/apps/frontend/src/app/auth/auth-layout.ts
+++ b/apps/frontend/src/app/auth/auth-layout.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Alerts } from '@uxcommon/components/alerts/alerts';
+
+/**
+ * Shared layout for authentication pages providing logo and alert wrapper.
+ */
+@Component({
+  selector: 'pc-auth-layout',
+  standalone: true,
+  imports: [CommonModule, Alerts],
+  template: `
+    <div class="bg-image flex min-h-screen font-light" data-theme="light">
+      <div class="card card-compact glass m-auto w-96 shadow-xl">
+        <div class="card-title mb-0 shadow-lg">
+          <img class="p-5" src="assets/logo.svg" />
+        </div>
+        <pc-alerts />
+        <div class="card-body">
+          <ng-content />
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class AuthLayoutComponent {}

--- a/apps/frontend/src/app/auth/auth-utils.ts
+++ b/apps/frontend/src/app/auth/auth-utils.ts
@@ -1,0 +1,33 @@
+import { AbstractControl, FormBuilder, FormControl, NonNullableFormBuilder, Validators } from '@angular/forms';
+
+// Consolidated form control builders and password breach utilities
+
+export type AnyFormBuilder = FormBuilder | NonNullableFormBuilder;
+
+/**
+ * Creates a standard email form control with required and email validators.
+ */
+export function emailControl(fb: AnyFormBuilder) {
+  return fb.control('', { validators: [Validators.required, Validators.email] });
+}
+
+/**
+ * Creates a password form control with required and minimum length validators.
+ */
+export function passwordControl(fb: AnyFormBuilder) {
+  return fb.control('', { validators: [Validators.required, Validators.minLength(8)] });
+}
+
+/**
+ * Returns the number of times the provided control's value was found in data breaches.
+ */
+export function passwordBreachNumber(control: AbstractControl | null | undefined) {
+  return (control?.errors as any)?.pwnedPasswordOccurrence;
+}
+
+/**
+ * Indicates whether the provided control's value appears in known data breaches.
+ */
+export function passwordInBreach(control: AbstractControl | null | undefined) {
+  return !!passwordBreachNumber(control);
+}

--- a/apps/frontend/src/app/auth/new-password-page/new-password-page.html
+++ b/apps/frontend/src/app/auth/new-password-page/new-password-page.html
@@ -1,74 +1,47 @@
 <!-- Template for setting a new password after verifying a reset code. -->
-<div class="bg-image flex min-h-screen font-light" data-theme="light">
-  <div class="card card-compact glass m-auto w-96 shadow-xl">
-    <div class="card-title bg-primary mb-10 w-full">
-      <img class="p-5" src="assets/logo.svg" />
-    </div>
-    <pc-alerts />
-    <div class="card-body mt-0 w-full">
-      @if (!error()) {
-      <form [formGroup]="form">
-        <div class="space-y-4">
-          <div class="space-y-0">
-            <label class="label text-base"> Please select a new password </label>
-            <label class="group relative block">
-              <pc-icon
-                class="group-focus-within:text-primary pointer-events-none absolute left-3 top-1/3 h-4 w-4 -translate-y-1/2 transform pt-1 text-sm text-gray-300"
-                name="magnifying-glass"
-              />
-
-              <input
-                class="input-pplcrm pl-11 pr-8"
-                [type]="getVisibility()"
-                formControlName="password"
-                autocomplete="current-password"
-                placeholder="Enter your password"
-              />
-
-              <pc-icon
-                class="absolute right-3 top-1/3 h-3 w-3 -translate-y-1/2 transform cursor-pointer pr-5 pt-1 text-xs text-gray-500"
-                [name]="getVisibilityIcon()"
-                (click)="toggleVisibility()"
-              />
-            </label>
-            @if (passwordInBreach()) {
-            <span class="label-text-alt text-error"
-              >This is not a safe password as it has been in
-              <span class="font-bold">{{ passwordBreachNumber() | number: '1.0-0' }}</span>
-              data breaches before. You should select a different password.</span
-            >
-            } @else if (password?.dirty && password?.invalid) {
-            <span class="label-text-alt text-error">Your password should have at least 8 characters</span>
-            }
-          </div>
-
-          <div>
-            <button
-              type="submit"
-              class="btn btn-primary w-full"
-              (click)="submit()"
-              [disabled]="loading() || !password?.valid"
-            >
-              @if (loading()) {
-              <span class="loading loading-dots loading-lg text-primary"></span>
-              } @else { Submit }
-            </button>
-          </div>
-        </div>
-      </form>
-      } @else {
-      <label class="label text-lg font-semibold"> Password Reset Failed </label>
-      <label class="label text-base">
-        The password reset link expired or something else went wrong. Please request a password reset link again.
-      </label>
-      <button type="submit" class="btn btn-primary w-full" routerLink="/resetpassword">Reset Password</button>
-      }
-      <div class="text-base-400 text-center text-xs">
-        <span>
-          Copyright © 2024
-          <a href="" rel="" target="_blank" title="CampaignRaven" class="link link-hover">CampaignRaven</a></span
+<pc-auth-layout>
+  @if (!error()) {
+  <form [formGroup]="form">
+    <div class="space-y-4">
+      <div class="space-y-0">
+        <label class="label text-base"> Please select a new password </label>
+        <pc-password-input [control]="password" autocomplete="current-password" placeholder="Enter your password" [pwned]="true"></pc-password-input>
+        @if (passwordInBreach(password)) {
+        <span class="label-text-alt text-error"
+          >This is not a safe password as it has been in
+          <span class="font-bold">{{ passwordBreachNumber(password) | number: '1.0-0' }}</span>
+          data breaches before. You should select a different password.</span
         >
+        } @else if (password?.dirty && password?.invalid) {
+        <span class="label-text-alt text-error">Your password should have at least 8 characters</span>
+        }
+      </div>
+
+      <div>
+        <button
+          type="submit"
+          class="btn btn-primary w-full"
+          (click)="submit()"
+          [disabled]="loading() || !password?.valid"
+        >
+          @if (loading()) {
+          <span class="loading loading-dots loading-lg text-primary"></span>
+          } @else { Submit }
+        </button>
       </div>
     </div>
+  </form>
+  } @else {
+  <label class="label text-lg font-semibold"> Password Reset Failed </label>
+  <label class="label text-base">
+    The password reset link expired or something else went wrong. Please request a password reset link again.
+  </label>
+  <button type="submit" class="btn btn-primary w-full" routerLink="/resetpassword">Reset Password</button>
+  }
+  <div class="text-base-400 text-center text-xs">
+    <span>
+      Copyright © 2024
+      <a href="" rel="" target="_blank" title="CampaignRaven" class="link link-hover">CampaignRaven</a></span
+    >
   </div>
-</div>
+</pc-auth-layout>

--- a/apps/frontend/src/app/auth/new-password-page/new-password-page.ts
+++ b/apps/frontend/src/app/auth/new-password-page/new-password-page.ts
@@ -3,18 +3,23 @@
  */
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, inject, signal } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Icon } from '@icons/icon';
-import { PasswordCheckerModule } from '@triangular/password-checker';
 import { AlertService } from '@uxcommon/components/alerts/alert-service';
-import { Alerts } from '@uxcommon/components/alerts/alerts';
 
+import { AuthLayoutComponent } from 'apps/frontend/src/app/auth/auth-layout';
+import { PasswordInputComponent } from 'apps/frontend/src/app/auth/password-input';
+import {
+  passwordControl,
+  passwordBreachNumber,
+  passwordInBreach,
+} from 'apps/frontend/src/app/auth/auth-utils';
 import { AuthService } from 'apps/frontend/src/app/auth/auth-service';
 
 @Component({
   selector: 'pc-new-password',
-  imports: [CommonModule, ReactiveFormsModule, RouterLink, PasswordCheckerModule, Icon, Alerts],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, Icon, AuthLayoutComponent, PasswordInputComponent],
   templateUrl: './new-password-page.html',
 })
 /**
@@ -30,9 +35,6 @@ export class NewPasswordPage implements OnInit {
   /** Reset code extracted from query params */
   private code: string | null = null;
 
-  /** Flag to control password visibility toggle */
-  private hidePassword = true;
-
   /** Error state to control UI feedback */
   protected readonly error = signal(false);
 
@@ -44,30 +46,18 @@ export class NewPasswordPage implements OnInit {
 
   /** Reactive form with the new password control */
   public form = this.fb.group({
-    password: ['', [Validators.required, Validators.minLength(8)]],
+    password: passwordControl(this.fb),
   });
+
+  /** Utilities for password breach checking */
+  protected passwordBreachNumber = passwordBreachNumber;
+  protected passwordInBreach = passwordInBreach;
 
   /**
    * Get the password form control.
    */
   public get password() {
     return this.form.get('password');
-  }
-
-  /**
-   * Get the appropriate input type based on password visibility state.
-   * @returns `'password'` or `'text'`
-   */
-  public getVisibility() {
-    return this.hidePassword ? 'password' : 'text';
-  }
-
-  /**
-   * Get the icon name for password visibility toggle.
-   * @returns `'eye-slash'` or `'eye'`
-   */
-  public getVisibilityIcon() {
-    return this.hidePassword ? 'eye-slash' : 'eye';
   }
 
   /**
@@ -111,34 +101,4 @@ export class NewPasswordPage implements OnInit {
     }
   }
 
-  /**
-   * Toggle the visibility of the password input.
-   */
-  public toggleVisibility() {
-    this.hidePassword = !this.hidePassword;
-  }
-
-  /**
-   * Get the number of known password breaches for the entered password (if any).
-   * Uses third-party library, so the error object is typed as `any`.
-   *
-   * @returns Number of password breaches or undefined
-   */
-  protected passwordBreachNumber() {
-    // This uses an external library. I can't find any exported interface that
-    // has the pwnedPasswordOccurrence property, so I am forced to use 'as any'
-    return (this.password?.errors as any)?.pwnedPasswordOccurrence;
-  }
-
-  /**
-   * Check whether the password was found in a known data breach.
-   * Uses third-party library, so the error object is typed as `any`.
-   *
-   * @returns True if password is in a breach, false otherwise
-   */
-  protected passwordInBreach() {
-    // This uses an external library. I can't find any exported interface that
-    // has the pwnedPasswordOccurrence property, so I am forced to use 'as any'
-    return (this?.password?.errors as any)?.pwnedPasswordOccurrence;
-  }
 }

--- a/apps/frontend/src/app/auth/password-input.ts
+++ b/apps/frontend/src/app/auth/password-input.ts
@@ -1,0 +1,64 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { Icon } from '@icons/icon';
+import { PasswordCheckerModule } from '@triangular/password-checker';
+
+/**
+ * Reusable password input with visibility toggle and optional breach checking.
+ */
+@Component({
+  selector: 'pc-password-input',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, Icon, PasswordCheckerModule],
+  template: `
+    <label class="group relative block">
+      <pc-icon
+        [size]="4"
+        class="pointer-events-none absolute left-3 top-1/3 h-1 w-4 -translate-y-1/2 transform text-sm text-gray-300"
+        name="lock-closed"
+      />
+
+      <input
+        class="input-pplcrm pl-11 pr-8 text-sm"
+        [type]="getVisibility()"
+        [formControl]="control"
+        [attr.autocomplete]="autocomplete"
+        [attr.placeholder]="placeholder"
+        [attr.maxlength]="maxlength"
+        [pwnedPasswordValidator]="pwned"
+      />
+
+      <pc-icon
+        [size]="4"
+        class="absolute right-3 top-1/3 h-3 w-3 -translate-y-1/2 transform cursor-pointer pr-5 pt-1 text-xs text-gray-500"
+        [name]="getVisibilityIcon()"
+        (click)="toggleVisibility()"
+      />
+    </label>
+  `,
+})
+export class PasswordInputComponent {
+  @Input({ required: true }) control!: FormControl;
+  @Input() placeholder = 'Enter your password';
+  @Input() autocomplete = 'new-password';
+  @Input() maxlength?: number;
+  @Input() pwned = false;
+
+  protected hidePassword = true;
+
+  /** Returns input type based on visibility state */
+  public getVisibility() {
+    return this.hidePassword ? 'password' : 'text';
+  }
+
+  /** Returns the icon name for the visibility toggle */
+  public getVisibilityIcon() {
+    return this.hidePassword ? 'eye-slash' : 'eye';
+  }
+
+  /** Toggles password visibility */
+  public toggleVisibility() {
+    this.hidePassword = !this.hidePassword;
+  }
+}

--- a/apps/frontend/src/app/auth/signin-page/signin-page.html
+++ b/apps/frontend/src/app/auth/signin-page/signin-page.html
@@ -1,103 +1,68 @@
 <!-- Template for user sign-in with email and password form. -->
-<div class="bg-image flex min-h-screen font-light" data-theme="light">
-  <div class="card card-compact glass m-auto w-96 shadow-xl">
-    <div class="card-title mb-0 shadow-lg">
-      <img class="p-5" src="assets/logo.svg" />
-    </div>
-    <pc-alerts />
-    <div class="card-body">
-      <label class="label text-base text-neutral-600">Enter your email and password to sign in</label>
-      <form [formGroup]="form">
-        <div class="space-y-3">
-          <label class="relative block">
-            <pc-icon
-              [size]="4"
-              class="focus-within:text-primary pointer-events-none absolute left-3 top-1/3 h-1 w-4 -translate-y-1/2 transform pt-0.5 text-sm text-gray-300"
-              name="at-symbol"
-            />
+<pc-auth-layout>
+  <label class="label text-base text-neutral-600">Enter your email and password to sign in</label>
+  <form [formGroup]="form">
+    <div class="space-y-3">
+      <label class="relative block">
+        <pc-icon
+          [size]="4"
+          class="focus-within:text-primary pointer-events-none absolute left-3 top-1/3 h-1 w-4 -translate-y-1/2 transform pt-0.5 text-sm text-gray-300"
+          name="at-symbol"
+        />
 
-            <input
-              type="email"
-              placeholder="Enter your email"
-              formControlName="email"
-              aria-placeholder="email"
-              class="input-pplcrm pl-11 text-sm"
-              autocomplete="email"
-            />
-          </label>
+        <input
+          type="email"
+          placeholder="Enter your email"
+          formControlName="email"
+          aria-placeholder="email"
+          class="input-pplcrm pl-11 text-sm"
+          autocomplete="email"
+        />
+      </label>
 
-          @if (email.dirty && email.invalid) {
-          <span class="label-text-alt text-error">Please enter a valid email</span>
-          }
+      @if (email.dirty && email.invalid) {
+      <span class="label-text-alt text-error">Please enter a valid email</span>
+      }
 
-          <label class="group relative block">
-            <pc-icon
-              [size]="4"
-              class="focus-within:text-primary pointer-events-none absolute left-3 top-1/3 h-1 w-4 -translate-y-1/2 transform text-sm text-gray-300"
-              name="lock-closed"
-            />
+      <pc-password-input [control]="password" autocomplete="current-password" placeholder="Enter your password"></pc-password-input>
 
-            <input
-              class="input-pplcrm pl-11 pr-8 text-sm"
-              [class.border-error]="hasError()"
-              [type]="getVisibility()"
-              formControlName="password"
-              autocomplete="current-password"
-              placeholder="Enter your password"
-            />
-
-            <pc-icon
-              [size]="4"
-              class="absolute right-3 top-1/3 h-3 w-3 -translate-y-1/2 transform cursor-pointer pr-5 pt-2 text-xs text-gray-500"
-              [name]="getVisibilityIcon()"
-              (click)="toggleVisibility()"
-            />
-          </label>
-
-          <!--
-          @if (password?.invalid) {
-            <span class="label-text-alt text-slate-400">Min character: 8</span>
-          }-->
-
-          <div class="flex items-center justify-between pt-2">
-            <div class="flex items-center">
-              <input
-                id="remember_me"
-                name="remember_me"
-                type="checkbox"
-                class="checkbox checkbox-primary checkbox-sm"
-                [checked]="persistence"
-                (change)="togglePersistence($event.target)"
-              />
-              <label for="remember_me" class="ml-2 block text-sm text-neutral-600"> Remember me </label>
-            </div>
-            <div class="text-sm">
-              <a routerLink="/resetpassword" class="link link-hover text-neutral-600"> Forgot your password? </a>
-            </div>
-          </div>
-          <div>
-            <button
-              type="submit"
-              class="btn btn-primary w-full"
-              (click)="signIn()"
-              [disabled]="loading() || (form.dirty && form.invalid)"
-            >
-              @if (loading()) {
-              <span class="loading loading-dots loading-lg text-primary"></span>
-              } @else { SIGN IN }
-            </button>
-          </div>
+      <div class="flex items-center justify-between pt-2">
+        <div class="flex items-center">
+          <input
+            id="remember_me"
+            name="remember_me"
+            type="checkbox"
+            class="checkbox checkbox-primary checkbox-sm"
+            [checked]="persistence"
+            (change)="togglePersistence($event.target)"
+          />
+          <label for="remember_me" class="ml-2 block text-sm text-neutral-600"> Remember me </label>
         </div>
-      </form>
-      <div class="py-3 text-center">
-        <a routerLink="/signup" class="link link-hover text-neutral-600">SIGN UP</a>
+        <div class="text-sm">
+          <a routerLink="/resetpassword" class="link link-hover text-neutral-600"> Forgot your password? </a>
+        </div>
       </div>
-      <div class="text-center text-xs text-neutral-500">
-        <span>
-          Copyright © 2024
-          <a href="" rel="" target="_blank" title="CampaignRaven" class="link link-hover">CampaignRaven</a></span
+      <div>
+        <button
+          type="submit"
+          class="btn btn-primary w-full"
+          (click)="signIn()"
+          [disabled]="loading() || (form.dirty && form.invalid)"
         >
+          @if (loading()) {
+          <span class="loading loading-dots loading-lg text-primary"></span>
+          } @else { SIGN IN }
+        </button>
       </div>
     </div>
+  </form>
+  <div class="py-3 text-center">
+    <a routerLink="/signup" class="link link-hover text-neutral-600">SIGN UP</a>
   </div>
-</div>
+  <div class="text-center text-xs text-neutral-500">
+    <span>
+      Copyright © 2024
+      <a href="" rel="" target="_blank" title="CampaignRaven" class="link link-hover">CampaignRaven</a></span
+    >
+  </div>
+</pc-auth-layout>

--- a/apps/frontend/src/app/auth/signin-page/signin-page.ts
+++ b/apps/frontend/src/app/auth/signin-page/signin-page.ts
@@ -9,7 +9,6 @@ import {
   NonNullableFormBuilder,
   ReactiveFormsModule,
   ValidatorFn,
-  Validators,
 } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { JSendFailError } from '@common';
@@ -17,8 +16,10 @@ import { Icon } from '@icons/icon';
 import { TokenService } from '@services/api/token-service';
 import { TRPCClientError } from '@trpc/client';
 import { AlertService } from '@uxcommon/components/alerts/alert-service';
-import { Alerts } from '@uxcommon/components/alerts/alerts';
 
+import { AuthLayoutComponent } from 'apps/frontend/src/app/auth/auth-layout';
+import { PasswordInputComponent } from 'apps/frontend/src/app/auth/password-input';
+import { emailControl, passwordControl } from 'apps/frontend/src/app/auth/auth-utils';
 import { AuthService } from 'apps/frontend/src/app/auth/auth-service';
 
 /**
@@ -46,7 +47,7 @@ import { AuthService } from 'apps/frontend/src/app/auth/auth-service';
  */
 @Component({
   selector: 'pc-login',
-  imports: [ReactiveFormsModule, RouterLink, Icon, Alerts],
+  imports: [ReactiveFormsModule, RouterLink, Icon, AuthLayoutComponent, PasswordInputComponent],
   templateUrl: './signin-page.html',
 })
 export class SignInPage {
@@ -59,16 +60,13 @@ export class SignInPage {
   /** Signal indicating whether login loading is in progress */
   protected readonly loading = signal(false);
 
-  /** Controls whether the password is visible or masked */
-  protected hidePassword = true;
-
   /** Reference to token persistence setting (localStorage vs session) */
   protected persistence = this.tokenService.getPersistence();
 
   /** Form group capturing the user's email and password */
   public form = this.fb.group({
-    email: this.fb.control('', { validators: [Validators.required, Validators.email] }),
-    password: this.fb.control('', { validators: [Validators.required, Validators.minLength(8)] }),
+    email: emailControl(this.fb),
+    password: passwordControl(this.fb),
   });
 
   /**
@@ -86,22 +84,6 @@ export class SignInPage {
 
   public get password(): FormControl<string> {
     return this.form.controls.password;
-  }
-
-  /**
-   * Returns input type based on visibility toggle.
-   * @returns 'password' or 'text'
-   */
-  public getVisibility() {
-    return this.hidePassword ? 'password' : 'text';
-  }
-
-  /**
-   * Returns icon name for password visibility toggle.
-   * @returns 'eye' or 'eye-slash'
-   */
-  public getVisibilityIcon() {
-    return this.hidePassword ? 'eye-slash' : 'eye';
   }
 
   /**
@@ -168,28 +150,6 @@ export class SignInPage {
     this.tokenService.setPersistence((target as HTMLInputElement).checked);
   }
 
-  /**
-   * Toggles the password visibility state.
-   */
-  public toggleVisibility() {
-    this.hidePassword = !this.hidePassword;
-  }
-
-  /**
-   * Gets any custom form-level error messages.
-   * @returns The error message or null
-   */
-  protected getError() {
-    return this.form?.errors ? this.form?.errors['message'] : null;
-  }
-
-  /**
-   * Checks if any form-level error exists.
-   * @returns True if there's an error message; otherwise false
-   */
-  protected hasError() {
-    return this.getError()?.length;
-  }
 }
 
 export function emailSafeValidator(): ValidatorFn {

--- a/apps/frontend/src/app/auth/signup-page/signup-page.html
+++ b/apps/frontend/src/app/auth/signup-page/signup-page.html
@@ -1,13 +1,7 @@
 <!-- Template for user sign-up, capturing account and organization details. -->
-<div class="bg-image flex min-h-screen font-light" data-theme="light">
-  <div class="card card-compact glass m-auto w-96 rounded-xl shadow-xl">
-    <div class="card-title shadow-lg">
-      <img src="assets/logo.svg" class="p-5" />
-    </div>
-    <pc-alerts />
-    <div class="card-body">
-      <form [formGroup]="form" class="flex flex-col gap-3">
-        <label class="label text-base text-neutral-600">Enter basic info to create your account </label>
+<pc-auth-layout>
+  <form [formGroup]="form" class="flex flex-col gap-3">
+    <label class="label text-base text-neutral-600">Enter basic info to create your account </label>
         <label class="relative block">
           <pc-icon
             [size]="4"
@@ -75,44 +69,14 @@
         <span class="label-text-alt text-error -my-2 pb-2">Please enter a valid email</span>
         }
 
-        <label class="group relative block">
-          <pc-icon
-            [size]="4"
-            class="pointer-events-none absolute left-3 top-1/3 h-1 w-4 -translate-y-1/2 transform text-sm text-gray-300"
-            name="lock-closed"
-          />
+        <pc-password-input [control]="password" autocomplete="new-password" placeholder="Enter your password" maxlength="72" [pwned]="true"></pc-password-input>
 
-          <input
-            pwnedPasswordValidator
-            class="input-pplcrm pl-11 pr-8 text-sm"
-            [type]="getVisibility()"
-            formControlName="password"
-            autocomplete="new-password"
-            placeholder="Enter your password"
-            maxlength="72"
-            required
-          />
-
-          <pc-icon
-            [size]="4"
-            class="absolute right-3 top-1/3 h-3 w-3 -translate-y-1/2 transform cursor-pointer pr-5 pt-1 text-xs text-gray-500"
-            [name]="getVisibilityIcon()"
-            (click)="toggleVisibility()"
-          />
-        </label>
-
-        @if (passwordInBreach()) {
+        @if (passwordInBreach(password)) {
         <span class="label-text-alt text-error -my-2 pb-2"
           >This is not a safe password as it has been in
-          <span class="font-bold">{{ passwordBreachNumber() | number: '1.0-0' }}</span>
+          <span class="font-bold">{{ passwordBreachNumber(password) | number: '1.0-0' }}</span>
           data breaches before. You should select a different password.</span
         >
-        <!--
-        } @else if (password?.dirty && password?.invalid) {
-          <span class="label-text-alt text-error -my-2 pb-2"
-            >Your password should have at least 8 characters</span
-          >
-          -->
         } @else {
         <span
           class="label-text-alt -my-2 pb-2 pr-1 text-right"
@@ -133,10 +97,8 @@
           >By joining, you agree to the <a href="#" class="link">Terms & Conditions</a> and
           <a href="#" class="link">Privacy Policy</a>.</span
         >
-      </form>
+        </form>
       <span class="label-text py-3 text-center"
         >Already have an account? <a routerLink="/signin" class="link">Sign In</a>.</span
       >
-    </div>
-  </div>
-</div>
+  </pc-auth-layout>

--- a/apps/frontend/src/app/auth/signup-page/signup-page.ts
+++ b/apps/frontend/src/app/auth/signup-page/signup-page.ts
@@ -7,10 +7,16 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { IAuthUser, signUpInputType } from '@common';
 import { Icon } from '@icons/icon';
-import { PasswordCheckerModule } from '@triangular/password-checker';
 import { AlertService } from '@uxcommon/components/alerts/alert-service';
-import { Alerts } from '@uxcommon/components/alerts/alerts';
 
+import { AuthLayoutComponent } from 'apps/frontend/src/app/auth/auth-layout';
+import { PasswordInputComponent } from 'apps/frontend/src/app/auth/password-input';
+import {
+  emailControl,
+  passwordControl,
+  passwordBreachNumber,
+  passwordInBreach,
+} from 'apps/frontend/src/app/auth/auth-utils';
 import { AuthService } from 'apps/frontend/src/app/auth/auth-service';
 
 /**
@@ -20,7 +26,7 @@ import { AuthService } from 'apps/frontend/src/app/auth/auth-service';
  */
 @Component({
   selector: 'pc-signup',
-  imports: [CommonModule, PasswordCheckerModule, ReactiveFormsModule, Icon, RouterModule, Alerts],
+  imports: [CommonModule, ReactiveFormsModule, Icon, RouterModule, AuthLayoutComponent, PasswordInputComponent],
   templateUrl: './signup-page.html',
 })
 export class SignUpPage {
@@ -31,16 +37,17 @@ export class SignUpPage {
   /** Reactive form with user registration fields */
   protected form = this.fb.group({
     organization: ['', [Validators.required]],
-    email: ['', [Validators.required, Validators.email]],
-    password: ['', [Validators.required, Validators.minLength(8)]],
+    email: emailControl(this.fb),
+    password: passwordControl(this.fb),
     first_name: ['', [Validators.required]],
     middle_names: [''],
     last_name: [''],
     terms: [''],
   });
 
-  /** Whether password input is hidden */
-  protected hidePassword = true;
+  /** Utilities for password breach checking */
+  protected passwordBreachNumber = passwordBreachNumber;
+  protected passwordInBreach = passwordInBreach;
 
   /** Signal indicating whether form submission is in progress */
   protected loading = signal(false);
@@ -78,22 +85,6 @@ export class SignUpPage {
   }
 
   /**
-   * Returns input type for password field based on visibility toggle.
-   * @returns 'password' or 'text'
-   */
-  public getVisibility() {
-    return this.hidePassword ? 'password' : 'text';
-  }
-
-  /**
-   * Returns icon name for visibility toggle.
-   * @returns 'eye' or 'eye-slash'
-   */
-  public getVisibilityIcon() {
-    return this.hidePassword ? 'eye-slash' : 'eye';
-  }
-
-  /**
    * Handles form submission for user registration.
    * Displays alerts for error or success states.
    */
@@ -117,28 +108,4 @@ export class SignUpPage {
       .finally(() => this.loading.set(false));
   }
 
-  /**
-   * Toggles password visibility.
-   */
-  public toggleVisibility() {
-    this.hidePassword = !this.hidePassword;
-  }
-
-  /**
-   * Returns the number of times the password was found in a data breach.
-   * Requires external library support.
-   * @returns Number of pwned password occurrences
-   */
-  protected passwordBreachNumber() {
-    return (this.password?.errors as any)?.pwnedPasswordOccurrence;
-  }
-
-  /**
-   * Returns whether the password was found in a data breach.
-   * Requires external library support.
-   * @returns Truthy if password was breached, falsy otherwise
-   */
-  protected passwordInBreach() {
-    return (this?.password?.errors as any)?.pwnedPasswordOccurrence;
-  }
 }


### PR DESCRIPTION
## Summary
- add `AuthLayoutComponent` to centralize common authentication page structure
- create reusable `PasswordInputComponent` with built-in visibility toggle and optional breach checking
- introduce `auth-utils` helpers for email/password controls and breach detection
- update sign-in, sign-up, and new-password pages to use shared layout, password input, and utilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx nx test frontend --runInBand` *(crashed: terminal unresponsive)*
- `npm run lint` *(fails: ENOENT: no such file or directory, open '/workspace/pplcrm/apps/frontend/src/app/pipes/*')*


------
https://chatgpt.com/codex/tasks/task_e_68ae3635319c832193336d3a21ca147f