### PR TITLE
feat: add lists grid and backend

### DIFF
--- a/apps/backend/src/app/_migrations/2025-01-14-lists.ts
+++ b/apps/backend/src/app/_migrations/2025-01-14-lists.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable('lists')
+    .addColumn('id', 'bigserial', (col) => col.unique())
+    .addColumn('tenant_id', 'bigint', (col) => col.notNull())
+    .addColumn('name', 'text', (col) => col.notNull())
+    .addColumn('description', 'text')
+    .addColumn('object', 'text', (col) => col.notNull().check(sql`object IN ('people','households')`))
+    .addColumn('is_dynamic', 'boolean', (col) => col.defaultTo(false))
+    .addColumn('definition', 'jsonb')
+    .addColumn('createdby_id', 'bigint', (col) => col.notNull())
+    .addColumn('updatedby_id', 'bigint', (col) => col.notNull())
+    .addColumn('created_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addColumn('updated_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addForeignKeyConstraint('fk_lists_tenant', ['tenant_id'], 'tenants', ['id'])
+    .addForeignKeyConstraint('fk_lists_createdby', ['createdby_id'], 'authusers', ['id'])
+    .addForeignKeyConstraint('fk_lists_updatedby', ['updatedby_id'], 'authusers', ['id'])
+    .addPrimaryKeyConstraint('lists_id_tenantid', ['id', 'tenant_id'])
+    .execute();
+
+  await db.schema
+    .createTable('map_lists_persons')
+    .addColumn('id', 'bigserial', (col) => col.unique())
+    .addColumn('tenant_id', 'bigint', (col) => col.notNull())
+    .addColumn('list_id', 'bigint', (col) => col.notNull())
+    .addColumn('person_id', 'bigint', (col) => col.notNull())
+    .addColumn('createdby_id', 'bigint', (col) => col.notNull())
+    .addColumn('updatedby_id', 'bigint', (col) => col.notNull())
+    .addColumn('created_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addColumn('updated_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addForeignKeyConstraint('fk_map_lists_persons_tenant', ['tenant_id'], 'tenants', ['id'])
+    .addForeignKeyConstraint('fk_map_lists_persons_list', ['list_id'], 'lists', ['id'])
+    .addForeignKeyConstraint('fk_map_lists_persons_person', ['person_id'], 'persons', ['id'])
+    .addPrimaryKeyConstraint('map_lists_persons_id_tenantid', ['id', 'tenant_id'])
+    .addUniqueConstraint('unique_list_person_per_tenant', ['tenant_id', 'list_id', 'person_id'])
+    .execute();
+
+  await db.schema
+    .createIndex('idx_map_lists_persons')
+    .on('map_lists_persons')
+    .columns(['tenant_id', 'list_id', 'person_id'])
+    .execute();
+
+  await db.schema
+    .createTable('map_lists_households')
+    .addColumn('id', 'bigserial', (col) => col.unique())
+    .addColumn('tenant_id', 'bigint', (col) => col.notNull())
+    .addColumn('list_id', 'bigint', (col) => col.notNull())
+    .addColumn('household_id', 'bigint', (col) => col.notNull())
+    .addColumn('createdby_id', 'bigint', (col) => col.notNull())
+    .addColumn('updatedby_id', 'bigint', (col) => col.notNull())
+    .addColumn('created_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addColumn('updated_at', 'timestamp', (col) => col.defaultTo(sql`now()`).notNull())
+    .addForeignKeyConstraint('fk_map_lists_households_tenant', ['tenant_id'], 'tenants', ['id'])
+    .addForeignKeyConstraint('fk_map_lists_households_list', ['list_id'], 'lists', ['id'])
+    .addForeignKeyConstraint('fk_map_lists_households_household', ['household_id'], 'households', ['id'])
+    .addPrimaryKeyConstraint('map_lists_households_id_tenantid', ['id', 'tenant_id'])
+    .addUniqueConstraint('unique_list_household_per_tenant', ['tenant_id', 'list_id', 'household_id'])
+    .execute();
+
+  await db.schema
+    .createIndex('idx_map_lists_households')
+    .on('map_lists_households')
+    .columns(['tenant_id', 'list_id', 'household_id'])
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable('map_lists_households').cascade().execute();
+  await db.schema.dropTable('map_lists_persons').cascade().execute();
+  await db.schema.dropTable('lists').cascade().execute();
+}

--- a/apps/backend/src/app/modules/lists/controller.ts
+++ b/apps/backend/src/app/modules/lists/controller.ts
@@ -1,0 +1,105 @@
+import { AddListType, IAuthKeyPayload, UpdateListType, getAllOptionsType } from '@common';
+
+import { QueryParams } from '../../lib/base.repo';
+import { BaseController } from '../../lib/base.controller';
+import { OperationDataType } from 'common/src/lib/kysely.models';
+import { ListsRepo } from './repositories/lists.repo';
+import { PersonsRepo } from '../persons/repositories/persons.repo';
+import { HouseholdRepo } from '../households/repositories/households.repo';
+
+/**
+ * Controller handling CRUD and reporting for lists of people or households.
+ */
+export class ListsController extends BaseController<'lists', ListsRepo> {
+  constructor() {
+    super(new ListsRepo());
+  }
+
+  /**
+   * Create a new list for the authenticated tenant.
+   */
+  public async addList(payload: AddListType, auth: IAuthKeyPayload) {
+    const repo = this.getRepo();
+    return repo.transaction().execute(async (trx) => {
+      const row = {
+        name: payload.name,
+        description: payload.description,
+        object: payload.object,
+        is_dynamic: payload.is_dynamic ?? false,
+        definition: payload.definition ?? null,
+        tenant_id: auth.tenant_id,
+        createdby_id: auth.user_id,
+        updatedby_id: auth.user_id,
+      };
+
+      const list = await repo.add({ row: row as OperationDataType<'lists', 'insert'> }, trx);
+
+      if (!row.is_dynamic && payload.definition) {
+        const def = payload.definition as any;
+        const options = { ...def };
+        const tags = options.tags as string[] | undefined;
+        delete (options as any).tags;
+
+        if (row.object === 'people') {
+          const personsRepo = new PersonsRepo();
+          const persons = await personsRepo.getAllWithAddress({
+            tenant_id: auth.tenant_id,
+            options,
+            tags,
+          }, trx);
+
+          const members = persons.rows.map((p: any) => ({
+            list_id: list.id,
+            person_id: p.id,
+            tenant_id: auth.tenant_id,
+            createdby_id: auth.user_id,
+            updatedby_id: auth.user_id,
+          }));
+          if (members.length) await repo.addPersons(members, trx);
+        } else if (row.object === 'households') {
+          const householdsRepo = new HouseholdRepo();
+          const households = await householdsRepo.getAllWithPeopleCount({
+            tenant_id: auth.tenant_id,
+            options,
+            tags,
+          }, trx);
+          const members = households.rows.map((h: any) => ({
+            list_id: list.id,
+            household_id: h.id,
+            tenant_id: auth.tenant_id,
+            createdby_id: auth.user_id,
+            updatedby_id: auth.user_id,
+          }));
+          if (members.length) await repo.addHouseholds(members, trx);
+        }
+      }
+
+      return list;
+    });
+  }
+
+  /**
+   * Fetch all lists including computed sizes and metadata.
+   */
+  public getAllWithCounts(auth: IAuthKeyPayload, options?: getAllOptionsType) {
+    return this.getRepo().getAllWithCounts({
+      tenant_id: auth.tenant_id,
+      options: options as QueryParams<'lists' | 'map_lists_persons' | 'map_lists_households' | 'authusers'>,
+    });
+  }
+
+  /**
+   * Update an existing list.
+   */
+  public updateList(id: string, row: UpdateListType, auth: IAuthKeyPayload) {
+    const rowWithUpdatedBy = {
+      ...row,
+      updatedby_id: auth.user_id,
+    };
+    return this.update({
+      tenant_id: auth.tenant_id,
+      id,
+      row: rowWithUpdatedBy as OperationDataType<'lists', 'update'>,
+    });
+  }
+}

--- a/apps/backend/src/app/modules/lists/repositories/lists.repo.ts
+++ b/apps/backend/src/app/modules/lists/repositories/lists.repo.ts
@@ -1,0 +1,113 @@
+import { SelectQueryBuilder, Transaction, sql } from 'kysely';
+
+import { BaseRepository, JoinedQueryParams, QueryParams } from '../../../lib/base.repo';
+import { Models, OperationDataType } from 'common/src/lib/kysely.models';
+
+/**
+ * Repository for interacting with the `lists` table and membership mappings.
+ */
+export class ListsRepo extends BaseRepository<'lists'> {
+  constructor() {
+    super('lists');
+  }
+
+  private personsMapRepo = new BaseRepository<'map_lists_persons'>('map_lists_persons');
+  private householdsMapRepo = new BaseRepository<'map_lists_households'>('map_lists_households');
+
+  /** Add many person members to a list. */
+  public addPersons(
+    rows: OperationDataType<'map_lists_persons', 'insert'>[],
+    trx?: Transaction<Models>,
+  ) {
+    return this.personsMapRepo.addMany({ rows }, trx);
+  }
+
+  /** Add many household members to a list. */
+  public addHouseholds(
+    rows: OperationDataType<'map_lists_households', 'insert'>[],
+    trx?: Transaction<Models>,
+  ) {
+    return this.householdsMapRepo.addMany({ rows }, trx);
+  }
+
+  /**
+   * Retrieve all lists with computed member counts and creator information.
+   *
+   * @param input.tenant_id - Tenant scope
+   * @param input.options - Optional filtering/pagination options
+   * @param trx - Optional transaction
+   */
+  public async getAllWithCounts(
+    input: {
+      tenant_id: string;
+      options?: QueryParams<'lists' | 'map_lists_persons' | 'map_lists_households' | 'authusers'>;
+    },
+    trx?: Transaction<Models>,
+  ): Promise<{ rows: { [x: string]: any }[]; count: number }> {
+    const options: JoinedQueryParams = input.options || {};
+    const tenantId = input.tenant_id;
+    const searchStr = options.searchStr?.toLowerCase();
+
+    const startRow = typeof options.startRow === 'number' ? options.startRow : 0;
+    const endRow = typeof options.endRow === 'number' && options.endRow > startRow ? options.endRow : startRow + 100;
+
+    const applyFilters = <QB extends SelectQueryBuilder<any, any, any>>(qb: QB) =>
+      qb
+        .leftJoin('map_lists_persons', 'map_lists_persons.list_id', 'lists.id')
+        .leftJoin('map_lists_households', 'map_lists_households.list_id', 'lists.id')
+        .leftJoin('authusers', 'authusers.id', 'lists.createdby_id')
+        .where('lists.tenant_id', '=', tenantId)
+        .$if(!!searchStr, (qb) => {
+          const text = `%${searchStr}%`;
+          return qb.where(sql`(LOWER(lists.name) LIKE ${text} OR LOWER(lists.description) LIKE ${text})` as any);
+        });
+
+    const countResult = await applyFilters(this.getSelect(trx))
+      .select(({ fn }) => [fn.count(sql`DISTINCT lists.id`).as('total')])
+      .execute();
+    const count = Number(countResult[0]?.['total'] || 0);
+
+    const rowsRaw = await applyFilters(this.getSelect(trx))
+      .select(({ fn }) => [
+        'lists.id',
+        'lists.name',
+        'lists.description',
+        'lists.object',
+        'lists.is_dynamic',
+        'lists.updated_at',
+        sql<number>`COUNT(DISTINCT map_lists_persons.person_id)` .as('people_count'),
+        sql<number>`COUNT(DISTINCT map_lists_households.household_id)` .as('household_count'),
+        sql<string>`CONCAT(authusers.first_name, ' ', authusers.last_name)` .as('created_by'),
+      ])
+      .groupBy([
+        'lists.id',
+        'lists.name',
+        'lists.description',
+        'lists.object',
+        'lists.is_dynamic',
+        'lists.updated_at',
+        'authusers.first_name',
+        'authusers.last_name',
+      ])
+      .$if(!!options.sortModel?.length, (qb) =>
+        options.sortModel!.reduce((acc, sort) => acc.orderBy(sort.colId as any, sort.sort), qb),
+      )
+      .offset(startRow)
+      .limit(endRow - startRow)
+      .execute();
+
+    const rows = rowsRaw.map((r: any) => ({
+      id: r.id,
+      name: r.name,
+      description: r.description,
+      object: r.object,
+      is_dynamic: r.is_dynamic,
+      updated_at: r.updated_at,
+      list_size: r.object === 'people' ? Number(r.people_count) : Number(r.household_count),
+      used_in: 0,
+      created_by: r.created_by,
+    }));
+
+    return { rows, count };
+  }
+}

--- a/apps/backend/src/app/modules/lists/trpc.router.ts
+++ b/apps/backend/src/app/modules/lists/trpc.router.ts
@@ -1,0 +1,55 @@
+/**
+ * tRPC router for managing list records and their members.
+ */
+import { AddListObj, UpdateListObj, getAllOptions } from '@common';
+import { z } from 'zod';
+
+import { authProcedure, router } from '../../../trpc';
+import { ListsController } from './controller';
+
+function add() {
+  return authProcedure.input(AddListObj).mutation(({ input, ctx }) => lists.addList(input, ctx.auth));
+}
+
+function count() {
+  return authProcedure.query(({ ctx }) => lists.getCount(ctx.auth.tenant_id));
+}
+
+function deleteList() {
+  return authProcedure.input(z.string()).mutation(({ input, ctx }) => lists.delete(ctx.auth.tenant_id, input));
+}
+
+function deleteLists() {
+  return authProcedure.input(z.array(z.string())).mutation(({ input, ctx }) => lists.deleteMany(ctx.auth.tenant_id, input));
+}
+
+function getAll() {
+  return authProcedure.query(({ ctx }) => lists.getAll(ctx.auth.tenant_id));
+}
+
+function getAllWithCounts() {
+  return authProcedure.input(getAllOptions).query(({ input, ctx }) => lists.getAllWithCounts(ctx.auth, input));
+}
+
+function getById() {
+  return authProcedure.input(z.string()).query(({ input, ctx }) => lists.getOneById({ tenant_id: ctx.auth.tenant_id, id: input }));
+}
+
+function update() {
+  return authProcedure
+    .input(z.object({ id: z.string(), data: UpdateListObj }))
+    .mutation(({ input, ctx }) => lists.updateList(input.id, input.data, ctx.auth));
+}
+
+const lists = new ListsController();
+
+export const ListsRouter = router({
+  add: add(),
+  count: count(),
+  getAll: getAll(),
+  getAllWithCounts: getAllWithCounts(),
+  getById: getById(),
+  update: update(),
+  delete: deleteList(),
+  deleteMany: deleteLists(),
+});

--- a/apps/backend/src/app/modules/trpc.ts
+++ b/apps/backend/src/app/modules/trpc.ts
@@ -9,6 +9,7 @@ import { PersonsRouter } from './persons/trpc.router';
 import { TagsRouter } from './tags/trpc.router';
 import { UserProfilesRouter } from './userprofiles/trpc.router';
 import { EmailsRouter } from './emails/trpc.router';
+import { ListsRouter } from './lists/trpc.router';
 
 /**
  * Registers and groups all tRPC routers for the application.
@@ -26,6 +27,7 @@ export const trpcRouter = router({
   households: HouseholdsRouter,
   persons: PersonsRouter,
   tags: TagsRouter,
+  lists: ListsRouter,
   emails: EmailsRouter,
 });
 
@@ -41,3 +43,4 @@ export { PersonsRouter } from './persons/trpc.router';
 export { TagsRouter } from './tags/trpc.router';
 export { UserProfilesRouter } from './userprofiles/trpc.router';
 export { EmailsRouter } from './emails/trpc.router';
+export { ListsRouter } from './lists/trpc.router';

--- a/apps/frontend/src/app/dashboard.routes.ts
+++ b/apps/frontend/src/app/dashboard.routes.ts
@@ -62,6 +62,25 @@ export const dashboardRoutes: Routes = [
   },
 
   {
+    path: 'lists',
+    children: [
+      {
+        path: '',
+        loadComponent: () => import('./experiences/lists/ui/lists-grid').then((m) => m.ListsGridComponent),
+        data: { shouldReuse: true, key: 'listsgridroot' },
+      },
+      {
+        path: 'add',
+        loadComponent: () => import('./experiences/lists/ui/list-detail').then((m) => m.ListDetail),
+      },
+      {
+        path: ':id',
+        loadComponent: () => import('./experiences/lists/ui/list-detail').then((m) => m.ListDetail),
+      },
+    ],
+  },
+
+  {
     path: 'volunteers',
     children: [
       {

--- a/apps/frontend/src/app/experiences/lists/services/lists-service.spec.ts
+++ b/apps/frontend/src/app/experiences/lists/services/lists-service.spec.ts
@@ -1,0 +1,8 @@
+/** Basic existence test for ListsService exports */
+import * as exported from './lists-service';
+
+describe('lists-service', () => {
+  it('should be defined', () => {
+    expect(exported).toBeDefined();
+  });
+});

--- a/apps/frontend/src/app/experiences/lists/services/lists-service.ts
+++ b/apps/frontend/src/app/experiences/lists/services/lists-service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+import { AddListType, UpdateListType, getAllOptionsType } from '@common';
+
+import { AbstractAPIService } from '../../../services/api/abstract-api.service';
+
+/** Service handling CRUD operations for list entities. */
+@Injectable({
+  providedIn: 'root',
+})
+export class ListsService extends AbstractAPIService<'lists', UpdateListType> {
+  /** Add a new list */
+  public add(row: AddListType) {
+    return this.api.lists.add.mutate(row);
+  }
+
+  /** No-op batch add implementation */
+  public addMany(rows: AddListType[]) {
+    return Promise.resolve(rows);
+  }
+
+  /** Tags are not supported on lists */
+  public attachTag(_id: string, _tag_name: string) {
+    return Promise.resolve();
+  }
+
+  public count(): Promise<number> {
+    return this.api.lists.count.query();
+  }
+
+  public async delete(id: string): Promise<boolean> {
+    return (await this.api.lists.delete.mutate(id)) !== null;
+  }
+
+  public async deleteMany(ids: string[]): Promise<boolean> {
+    return (await this.api.lists.deleteMany.mutate(ids)) !== null;
+  }
+
+  /** Tags are not supported on lists */
+  public detachTag(_id: string, _tag_name: string) {
+    return Promise.resolve(false);
+  }
+
+  public getAll(options?: getAllOptionsType) {
+    return this.getAllWithCounts(options);
+  }
+
+  public getAllWithCounts(options?: getAllOptionsType) {
+    return this.api.lists.getAllWithCounts.query(options, { signal: this.ac.signal });
+  }
+
+  public getById(id: string) {
+    return this.api.lists.getById.query(id);
+  }
+
+  public async getTags(_id: string) {
+    return [];
+  }
+
+  public update(id: string, data: UpdateListType) {
+    return this.api.lists.update.mutate({ id, data });
+  }
+}

--- a/apps/frontend/src/app/experiences/lists/ui/list-detail.html
+++ b/apps/frontend/src/app/experiences/lists/ui/list-detail.html
@@ -1,0 +1,25 @@
+<div class="flex min-h-full flex-col bg-base-100">
+  <progress class="progress w-full" [class.hidden]="!isLoading()"></progress>
+  <form [formGroup]="form" class="mx-5 mt-10 sm:mx-10">
+    <fieldset [disabled]="isLoading()">
+      <div class="flex flex-col gap-4">
+        <pc-form-input control="name" placeholder="List Name" />
+        <pc-textarea control="description" placeholder="Description"></pc-textarea>
+        <pc-form-input control="object" placeholder="Object (people or households)" />
+        <label class="label cursor-pointer">
+          <span class="label-text">Dynamic</span>
+          <input type="checkbox" class="toggle" formControlName="is_dynamic" />
+        </label>
+        <pc-tags
+          [tags]="tags()"
+          [enableAutoComplete]="true"
+          (tagAdded)="tagAdded($event)"
+          (tagRemoved)="tagRemoved($event)"
+        ></pc-tags>
+        <pc-form-input control="city" placeholder="City" />
+        <pc-add-btn-row [isLoading]="isLoading()" (btn1Clicked)="save()" [buttonsToShow]="list()?.id ? 'two' : 'three'"></pc-add-btn-row>
+      </div>
+    </fieldset>
+  </form>
+</div>
+

--- a/apps/frontend/src/app/experiences/lists/ui/list-detail.spec.ts
+++ b/apps/frontend/src/app/experiences/lists/ui/list-detail.spec.ts
@@ -1,0 +1,9 @@
+/** Basic existence test for ListDetail component */
+import * as exported from './list-detail';
+
+describe('list-detail', () => {
+  it('should be defined', () => {
+    expect(exported).toBeDefined();
+  });
+});
+

--- a/apps/frontend/src/app/experiences/lists/ui/list-detail.ts
+++ b/apps/frontend/src/app/experiences/lists/ui/list-detail.ts
@@ -1,0 +1,119 @@
+/**
+ * Component for creating or editing a list of people or households.
+ */
+import { Component, OnInit, inject, input, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { AddListType, UpdateListType } from '@common';
+import { AddBtnRow } from '@uxcommon/components/add-btn-row/add-btn-row';
+import { AlertService } from '@uxcommon/components/alerts/alert-service';
+import { FormInput } from '@uxcommon/components/form-input/formInput';
+import { Tags } from '@uxcommon/components/tags/tags';
+import { TextArea } from '@uxcommon/components/textarea/textarea';
+import { createLoadingGate } from '@uxcommon/loading-gate';
+
+import { ListsService } from '../services/lists-service';
+import { Lists } from 'common/src/lib/kysely.models';
+
+@Component({
+  selector: 'pc-list-detail',
+  imports: [FormInput, ReactiveFormsModule, TextArea, AddBtnRow, Tags, RouterModule],
+  templateUrl: './list-detail.html',
+})
+export class ListDetail implements OnInit {
+  private readonly alertSvc = inject(AlertService);
+  private readonly fb = inject(FormBuilder);
+  private readonly listsSvc = inject(ListsService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  private _loading = createLoadingGate();
+
+  protected isLoading = this._loading.visible;
+  protected list = signal<Lists | null>(null);
+
+  protected form = this.fb.group({
+    name: [''],
+    description: [''],
+    object: ['people'],
+    is_dynamic: [false],
+    city: [''],
+  });
+
+  protected id: string | null = null;
+  protected tags = signal<string[]>([]);
+
+  public mode = input<'new' | 'edit'>('edit');
+
+  constructor() {
+    if (this.mode() === 'edit') {
+      this.id = this.route.snapshot.paramMap.get('id');
+    }
+  }
+
+  public ngOnInit() {
+    this.loadList();
+  }
+
+  public save() {
+    const data = this.form.getRawValue() as AddListType;
+    return this.id ? this.update(data) : this.add(data);
+  }
+
+  protected tagAdded(tag: string) {
+    this.tags.update((t) => [...t, tag]);
+  }
+
+  protected tagRemoved(tag: string) {
+    this.tags.update((t) => t.filter((x) => x !== tag));
+  }
+
+  private buildDefinition(data: any) {
+    const definition: any = {};
+    if (this.tags().length) definition.tags = this.tags();
+    const filterModel: any = {};
+    if (data.city) filterModel.city = data.city;
+    if (Object.keys(filterModel).length) definition.filterModel = filterModel;
+    return definition;
+  }
+
+  private add(data: AddListType) {
+    const end = this._loading.begin();
+    const definition = this.buildDefinition(data);
+    this.listsSvc
+      .add({ ...data, definition })
+      .then(() => {
+        this.alertSvc.showSuccess('List added');
+        this.router.navigate(['lists']);
+      })
+      .catch((err: unknown) => this.alertSvc.showError(String(err)))
+      .finally(() => end());
+  }
+
+  private update(data: UpdateListType) {
+    if (!this.id) return;
+    const end = this._loading.begin();
+    const definition = this.buildDefinition(data);
+    this.listsSvc
+      .update(this.id, { ...data, definition })
+      .then(() => this.alertSvc.showSuccess('List updated'))
+      .catch((err: unknown) => this.alertSvc.showError(String(err)))
+      .finally(() => end());
+  }
+
+  private async loadList() {
+    if (!this.id) return;
+    const end = this._loading.begin();
+    try {
+      const list = (await this.listsSvc.getById(this.id)) as Lists;
+      this.list.set(list);
+      this.form.patchValue(list as any);
+      const def: any = list.definition || {};
+      if (Array.isArray(def.tags)) this.tags.set(def.tags);
+      if (def.filterModel?.city) this.form.get('city')?.setValue(def.filterModel.city);
+    } finally {
+      end();
+    }
+  }
+}
+

--- a/apps/frontend/src/app/experiences/lists/ui/lists-grid.spec.ts
+++ b/apps/frontend/src/app/experiences/lists/ui/lists-grid.spec.ts
@@ -1,0 +1,7 @@
+import * as exported from './lists-grid';
+
+describe('lists-grid', () => {
+  it('should be defined', () => {
+    expect(exported).toBeDefined();
+  });
+});

--- a/apps/frontend/src/app/experiences/lists/ui/lists-grid.ts
+++ b/apps/frontend/src/app/experiences/lists/ui/lists-grid.ts
@@ -1,0 +1,31 @@
+/**
+ * Grid component for viewing and editing lists of people or households.
+ */
+import { Component } from '@angular/core';
+import { UpdateListType } from '@common';
+import { ListsService } from '@experiences/lists/services/lists-service';
+import { DataGrid } from '@uxcommon/components/datagrid/datagrid';
+
+import { AbstractAPIService } from '../../../services/api/abstract-api.service';
+
+@Component({
+  selector: 'pc-lists-grid',
+  imports: [DataGrid],
+  template: `<pc-datagrid [colDefs]="col" [disableDelete]="false"></pc-datagrid>`,
+  providers: [{ provide: AbstractAPIService, useClass: ListsService }],
+})
+export class ListsGridComponent extends DataGrid<'lists', UpdateListType> {
+  protected col = [
+    { field: 'name', headerName: 'List Name', editable: true },
+    { field: 'description', headerName: 'Description', editable: true },
+    { field: 'object', headerName: 'Object', editable: true },
+    { field: 'list_size', headerName: 'List Size' },
+    { field: 'used_in', headerName: 'Used In' },
+    { field: 'updated_at', headerName: 'Last Updated' },
+    { field: 'created_by', headerName: 'Created By' },
+  ];
+
+  constructor() {
+    super();
+  }
+}

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -5,23 +5,29 @@ export { signInInputObj, signUpInputObj } from './lib/auth';
 export type {
   INow,
   AddTagType,
+  AddListType,
   PERSONINHOUSEHOLDTYPE,
   PersonsType,
+  ListsType,
   SettingsType,
   SortModelType,
   UpdateHouseholdsType,
   UpdatePersonsType,
   UpdateTagType,
+  UpdateListType,
   getAllOptionsType,
 } from './lib/models';
 
 export {
   AddTagObj,
+  AddListObj,
   PersonsObj,
+  ListsObj,
   SettingsObj,
   UpdateHouseholdsObj,
   UpdatePersonsObj,
   UpdateTagObj,
+  UpdateListObj,
   sortModelItem,
   getAllOptions,
 } from './lib/schema';

--- a/common/src/lib/kysely.models.ts
+++ b/common/src/lib/kysely.models.ts
@@ -36,6 +36,9 @@ export interface Models {
   map_households_tags: MapHouseholdsTags;
   map_peoples_tags: MapPeoplesTags;
   map_roles_users: MapRolesUsers;
+  lists: Lists;
+  map_lists_persons: MapListsPersons;
+  map_lists_households: MapListsHouseholds;
   persons: Persons;
   profiles: Profiles;
   roles: Roles;
@@ -200,6 +203,16 @@ interface MapRolesUsers extends RecordType {
   user_id: string;
 }
 
+export interface MapListsPersons extends RecordType {
+  list_id: string;
+  person_id: string;
+}
+
+interface MapListsHouseholds extends RecordType {
+  list_id: string;
+  household_id: string;
+}
+
 export interface Persons extends Omit<RecordType, 'createdby_id'> {
   campaign_id: string;
   household_id: string;
@@ -246,6 +259,14 @@ interface Sessions extends RecordType {
   refresh_token: Generated<string>;
   status: string;
   user_agent: string;
+}
+
+export interface Lists extends RecordType {
+  name: string;
+  description: string | null;
+  object: 'people' | 'households';
+  is_dynamic: boolean;
+  definition: Json | null;
 }
 
 export interface Tags extends RecordType {

--- a/common/src/lib/models.ts
+++ b/common/src/lib/models.ts
@@ -2,6 +2,7 @@ import type { z } from 'zod';
 
 import type {
   AddTagObj,
+  AddListObj,
   EmailCommentObj,
   EmailFolderObj,
   EmailObj,
@@ -11,6 +12,8 @@ import type {
   UpdateHouseholdsObj,
   UpdatePersonsObj,
   UpdateTagObj,
+  ListsObj,
+  UpdateListObj,
   getAllOptions,
   sortModelItem,
 } from './schema';
@@ -53,3 +56,9 @@ export type UpdatePersonsType = z.infer<typeof UpdatePersonsObj>;
 export type UpdateTagType = z.infer<typeof UpdateTagObj>;
 
 export type getAllOptionsType = z.infer<typeof getAllOptions>;
+
+export type AddListType = z.infer<typeof AddListObj>;
+
+export type ListsType = z.infer<typeof ListsObj>;
+
+export type UpdateListType = z.infer<typeof UpdateListObj>;

--- a/common/src/lib/schema.ts
+++ b/common/src/lib/schema.ts
@@ -16,6 +16,23 @@ export const AddTagObj = z.object({
    */
   description: z.string().nullable().optional(),
 });
+
+/**
+ * Object schema for creating a new list.
+ * Lists group people or households and can be static or dynamic.
+ */
+export const AddListObj = z.object({
+  /** Name of the list */
+  name: z.string(),
+  /** Optional description for the list */
+  description: z.string().nullable().optional(),
+  /** Target object type: people or households */
+  object: z.enum(['people', 'households']),
+  /** Indicates whether the list is dynamically generated */
+  is_dynamic: z.boolean().optional(),
+  /** Optional JSON definition for dynamic list filters */
+  definition: z.any().nullable().optional(),
+});
 export const EmailCommentObj = z.object({
   id: z.string(),
   email_id: z.string(),
@@ -126,6 +143,29 @@ export const UpdateTagObj = z.object({
    * The optional field that describes the tag.
    */
   description: z.string().nullable().optional(),
+});
+
+/**
+ * Schema representing a list record.
+ */
+export const ListsObj = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  object: z.enum(['people', 'households']),
+  is_dynamic: z.boolean().optional(),
+  definition: z.any().nullable().optional(),
+});
+
+/**
+ * Schema for updating an existing list.
+ */
+export const UpdateListObj = z.object({
+  name: z.string().optional(),
+  description: z.string().nullable().optional(),
+  object: z.enum(['people', 'households']).optional(),
+  is_dynamic: z.boolean().optional(),
+  definition: z.any().nullable().optional(),
 });
 export const sortModelItem = z
   .object({


### PR DESCRIPTION
## Summary
- add shared list schemas and models
- implement list CRUD in backend with counts
- introduce list grid and service in frontend
- support list creation with person/household filtering

## Testing
- `npm run lint` *(fails: ENOENT: no such file or directory, open '/workspace/pplcrm/apps/frontend/src/app/pipes/*')*
- `npx jest apps/frontend/src/app/experiences/lists/ui/lists-grid.spec.ts --runInBand` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npx jest apps/frontend/src/app/experiences/lists/ui/list-detail.spec.ts --runInBand` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68afb66907f483219c8ead367edb2f56