### PR TITLE
feat: support creating filtered lists

### DIFF
--- a/apps/backend/src/app/modules/lists/repositories/map-lists-households.repo.ts
+++ b/apps/backend/src/app/modules/lists/repositories/map-lists-households.repo.ts
@@ -1,0 +1,8 @@
+import { BaseRepository } from '../../../lib/base.repo';
+
+/** Repository for the `map_lists_households` table. */
+export class MapListsHouseholdsRepo extends BaseRepository<'map_lists_households'> {
+  constructor() {
+    super('map_lists_households');
+  }
+}

--- a/apps/backend/src/app/modules/lists/repositories/map-lists-persons.repo.ts
+++ b/apps/backend/src/app/modules/lists/repositories/map-lists-persons.repo.ts
@@ -1,0 +1,8 @@
+import { BaseRepository } from '../../../lib/base.repo';
+
+/** Repository for the `map_lists_persons` table. */
+export class MapListsPersonsRepo extends BaseRepository<'map_lists_persons'> {
+  constructor() {
+    super('map_lists_persons');
+  }
+}

--- a/apps/backend/src/app/modules/lists/trpc.router.spec.ts
+++ b/apps/backend/src/app/modules/lists/trpc.router.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for `ListsRouter` verifying list procedures delegate
+ * correctly to the controller and return expected results.
+ */
+import { ListsController } from './controller';
+import { ListsRouter } from './trpc.router';
+
+/** Test suite for list-related router procedures. */
+describe('ListsRouter', () => {
+  const ctx = { auth: { user_id: 'u1', tenant_id: 't1', session_id: 's1' } } as any;
+  let caller: ReturnType<typeof ListsRouter.createCaller>;
+
+  /** Mock controller methods and create router caller. */
+  beforeAll(() => {
+    jest.spyOn(ListsController.prototype, 'addList').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(ListsController.prototype, 'getAll').mockResolvedValue([{ id: '1' }] as any);
+    jest.spyOn(ListsController.prototype, 'getAllWithCounts').mockResolvedValue({ rows: [], count: 0 } as any);
+    jest.spyOn(ListsController.prototype, 'getOneById').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(ListsController.prototype, 'getCount').mockResolvedValue(1);
+    jest.spyOn(ListsController.prototype, 'updateList').mockResolvedValue({ id: '1' } as any);
+    jest.spyOn(ListsController.prototype, 'delete').mockResolvedValue(true as any);
+    jest.spyOn(ListsController.prototype, 'deleteMany').mockResolvedValue(true as any);
+    caller = ListsRouter.createCaller(ctx);
+  });
+
+  /** Restore mocked methods after tests. */
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** Tests adding a list returns the new ID. */
+  it('adds a list', async () => {
+    await expect(caller.add({ name: 'n', object: 'people' } as any)).resolves.toEqual({ id: '1' });
+  });
+
+  /** Tests counting lists. */
+  it('counts lists', async () => {
+    await expect(caller.count()).resolves.toBe(1);
+  });
+
+  /** Tests retrieving all lists. */
+  it('gets all lists', async () => {
+    await expect(caller.getAll()).resolves.toEqual([{ id: '1' }]);
+  });
+
+  /** Tests retrieving all lists with counts. */
+  it('gets all with counts', async () => {
+    await expect(caller.getAllWithCounts({} as any)).resolves.toEqual({ rows: [], count: 0 });
+  });
+
+  /** Tests retrieving a list by ID. */
+  it('gets list by id', async () => {
+    await expect(caller.getById('1')).resolves.toEqual({ id: '1' });
+  });
+
+  /** Tests updating a list. */
+  it('updates list', async () => {
+    await expect(caller.update({ id: '1', data: {} as any })).resolves.toEqual({ id: '1' });
+  });
+
+  /** Tests deleting a list. */
+  it('deletes list', async () => {
+    await expect(caller.delete('1')).resolves.toBeTruthy();
+  });
+
+  /** Tests deleting multiple lists. */
+  it('deletes many lists', async () => {
+    await expect(caller.deleteMany(['1'])).resolves.toBeTruthy();
+  });
+});

--- a/common/src/lib/schema.ts
+++ b/common/src/lib/schema.ts
@@ -31,7 +31,7 @@ export const AddListObj = z.object({
   /** Indicates whether the list is dynamically generated */
   is_dynamic: z.boolean().optional(),
   /** Optional JSON definition for dynamic list filters */
-  definition: z.any().nullable().optional(),
+  definition: z.lazy(() => getAllOptions).nullable().optional(),
 });
 export const EmailCommentObj = z.object({
   id: z.string(),
@@ -154,7 +154,7 @@ export const ListsObj = z.object({
   description: z.string().nullable().optional(),
   object: z.enum(['people', 'households']),
   is_dynamic: z.boolean().optional(),
-  definition: z.any().nullable().optional(),
+  definition: z.lazy(() => getAllOptions).nullable().optional(),
 });
 
 /**
@@ -165,7 +165,7 @@ export const UpdateListObj = z.object({
   description: z.string().nullable().optional(),
   object: z.enum(['people', 'households']).optional(),
   is_dynamic: z.boolean().optional(),
-  definition: z.any().nullable().optional(),
+  definition: z.lazy(() => getAllOptions).nullable().optional(),
 });
 export const sortModelItem = z
   .object({


### PR DESCRIPTION
## Summary
- allow lists to store filter definition and dynamic flag
- build static list members by querying persons or households
- cover lists router with unit tests

## Testing
- `npx eslint apps/backend/src/app/modules/lists/controller.ts apps/backend/src/app/modules/lists/repositories/map-lists-persons.repo.ts apps/backend/src/app/modules/lists/repositories/map-lists-households.repo.ts apps/backend/src/app/modules/lists/trpc.router.spec.ts common/src/lib/schema.ts`
- `npx jest src/app/modules/lists/trpc.router.spec.ts --runInBand -c apps/backend/jest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68afbecde5ec832182f9348c28dd0c0c