### PR TITLE
feat(frontend): add list creation UI

### DIFF
--- a/apps/frontend/src/app/dashboard.routes.ts
+++ b/apps/frontend/src/app/dashboard.routes.ts
@@ -69,6 +69,10 @@ export const dashboardRoutes: Routes = [
         loadComponent: () => import('./experiences/lists/ui/lists-grid').then((m) => m.ListsGridComponent),
         data: { shouldReuse: true, key: 'listsgridroot' },
       },
+      {
+        path: 'add',
+        loadComponent: () => import('./experiences/lists/ui/list-detail').then((m) => m.ListDetail),
+      },
     ],
   },
 

--- a/apps/frontend/src/app/experiences/lists/ui/list-detail.html
+++ b/apps/frontend/src/app/experiences/lists/ui/list-detail.html
@@ -1,0 +1,30 @@
+<div class="flex min-h-full flex-col bg-base-100">
+  <form [formGroup]="form" class="mx-5 my-10 flex flex-col gap-4 sm:mx-10">
+    <pc-form-input control="name" placeholder="List Name" icon="list-bullet" />
+    <pc-form-input control="description" placeholder="Description" icon="chat-bubble-left" />
+
+    <div class="flex flex-wrap items-center gap-4">
+      <label class="form-control w-full max-w-xs">
+        <span class="label-text">Object</span>
+        <select class="select select-bordered" formControlName="object">
+          <option value="people">People</option>
+          <option value="households">Households</option>
+        </select>
+      </label>
+      <label class="label cursor-pointer gap-2">
+        <span class="label-text">Dynamic</span>
+        <input type="checkbox" class="checkbox" formControlName="is_dynamic" />
+      </label>
+    </div>
+
+    <div class="h-96">
+      @if (form.get('object')?.value === 'people') {
+        <pc-people-filter-grid />
+      } @else {
+        <pc-household-filter-grid />
+      }
+    </div>
+
+    <pc-add-btn-row [isLoading]="isLoading()" (btn1Clicked)="save($event)"></pc-add-btn-row>
+  </form>
+</div>

--- a/apps/frontend/src/app/experiences/lists/ui/list-detail.ts
+++ b/apps/frontend/src/app/experiences/lists/ui/list-detail.ts
@@ -1,0 +1,126 @@
+import { Component, ViewChild, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AddListType, UpdatePersonsType, UpdateHouseholdsType, getAllOptionsType } from '@common';
+import { ListsService } from '@experiences/lists/services/lists-service';
+import { PersonsService } from '@experiences/persons/services/persons-service';
+import { HouseholdsService } from '@experiences/households/services/households-service';
+import { DataGrid } from '@uxcommon/components/datagrid/datagrid';
+import { AddBtnRow } from '@uxcommon/components/add-btn-row/add-btn-row';
+import { FormInput } from '@uxcommon/components/form-input/formInput';
+import { AlertService } from '@uxcommon/components/alerts/alert-service';
+import { createLoadingGate } from '@uxcommon/loading-gate';
+import { SearchService } from '@services/api/search-service';
+import { AbstractAPIService } from '@services/api/abstract-api.service';
+import { ColDef } from 'ag-grid-community';
+
+/** Grid component for filtering people when creating lists */
+@Component({
+  selector: 'pc-people-filter-grid',
+  imports: [DataGrid],
+  template: `<pc-datagrid
+    [colDefs]="col"
+    [disableDelete]="true"
+    [disableExport]="true"
+    [disableImport]="true"
+    [disableRefresh]="true"
+    [disableView]="true"
+  ></pc-datagrid>`,
+  providers: [{ provide: AbstractAPIService, useClass: PersonsService }],
+})
+export class PeopleFilterGrid extends DataGrid<'persons', UpdatePersonsType> {
+  protected col: ColDef[] = [
+    { field: 'first_name', headerName: 'First Name' },
+    { field: 'last_name', headerName: 'Last Name' },
+    { field: 'email', headerName: 'Email' },
+    { field: 'mobile', headerName: 'Mobile' },
+    { field: 'tags', headerName: 'Tags', filter: 'agSetColumnFilter' },
+    { field: 'city', headerName: 'City' },
+    { field: 'state', headerName: 'State' },
+    { field: 'zip', headerName: 'Zip' },
+  ];
+}
+
+/** Grid component for filtering households when creating lists */
+@Component({
+  selector: 'pc-household-filter-grid',
+  imports: [DataGrid],
+  template: `<pc-datagrid
+    [colDefs]="col"
+    [disableDelete]="true"
+    [disableExport]="true"
+    [disableImport]="true"
+    [disableRefresh]="true"
+    [disableView]="true"
+  ></pc-datagrid>`,
+  providers: [{ provide: AbstractAPIService, useClass: HouseholdsService }],
+})
+export class HouseholdFilterGrid extends DataGrid<'households', UpdateHouseholdsType> {
+  protected col: ColDef[] = [
+    { field: 'street1', headerName: 'Street 1' },
+    { field: 'city', headerName: 'City' },
+    { field: 'state', headerName: 'State' },
+    { field: 'zip', headerName: 'Zip' },
+    { field: 'people_count', headerName: 'People' },
+    { field: 'tags', headerName: 'Tags', filter: 'agSetColumnFilter' },
+  ];
+}
+
+/** Component for creating new lists. Allows building static or dynamic lists using filters. */
+@Component({
+  selector: 'pc-list-detail',
+  imports: [ReactiveFormsModule, FormInput, AddBtnRow, PeopleFilterGrid, HouseholdFilterGrid],
+  templateUrl: './list-detail.html',
+})
+export class ListDetail {
+  private readonly fb = inject(FormBuilder);
+  private readonly listsSvc = inject(ListsService);
+  private readonly alertSvc = inject(AlertService);
+  private readonly searchSvc = inject(SearchService);
+
+  private _loading = createLoadingGate();
+  protected isLoading = this._loading.visible;
+
+  protected form = this.fb.group({
+    name: ['', [Validators.required]],
+    description: [''],
+    object: ['people'],
+    is_dynamic: [false],
+  });
+
+  @ViewChild(PeopleFilterGrid) private peopleGrid?: PeopleFilterGrid;
+  @ViewChild(HouseholdFilterGrid) private householdsGrid?: HouseholdFilterGrid;
+
+  /** Save the list using current filters */
+  protected save(done: () => void) {
+    const formValue = this.form.getRawValue();
+    const gridApi =
+      formValue.object === 'people'
+        ? this.peopleGrid?.api
+        : this.householdsGrid?.api;
+
+    const definition: getAllOptionsType = {
+      searchStr: this.searchSvc.getFilterText(),
+      filterModel: gridApi?.getFilterModel() ?? {},
+      sortModel: gridApi?.getSortModel() ?? [],
+    } as getAllOptionsType;
+
+    const payload: AddListType = {
+      name: formValue.name!,
+      description: formValue.description ?? null,
+      object: formValue.object as 'people' | 'households',
+      is_dynamic: formValue.is_dynamic ?? false,
+      definition,
+    };
+
+    const end = this._loading.begin();
+    this.listsSvc
+      .add(payload)
+      .then(() => {
+        this.alertSvc.showSuccess('List added');
+        done();
+      })
+      .catch((err: unknown) => this.alertSvc.showError(String(err)))
+      .finally(() => end());
+  }
+}
+


### PR DESCRIPTION
## Summary
- add ListDetail component with filtering grids for people and households
- support dynamic or static list creation with filters
- wire up /lists/add route

## Testing
- `npx nx lint frontend`
- `npx nx test frontend --runInBand` *(fails: terminal crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68b050ec9ddc83219773ddf48e96cc2d