### PR TITLE
test(security): cross-tenant IDOR probe at the API layer

### DIFF
--- a/.claude/skills/pplcrm-quality-gate/SKILL.md
+++ b/.claude/skills/pplcrm-quality-gate/SKILL.md
@@ -39,8 +39,37 @@ If that exits 0, the pre-commit hook's `*.{ts,html}` step will pass. This is the
 Heads-up on **pre-existing failures** — check whether the flagged lines/tests are yours before burning time:
 
 - ~~`nx lint backend` fails on 2 `donation_pledges` `no-unscoped-db-query` errors~~ — fixed; `nx lint backend` passes clean as of 2026-07-21.
-- ~~`nx test backend` has 18 pre-existing failing tests (web-forms/events/volunteer-events public-submission specs)~~ — fixed; those all pass as of 2026-07-24. `job-claim.spec.ts` can still fail in the full parallel run but passes in isolation (test-parallelism flake). Deploy CI has **no test step**, which is how broken specs land on main.
-- `nx test frontend` has **2 pre-existing failing tests** (verified failing at HEAD `42aac912` on 2026-07-24, files untouched since): `services/api/user-message.spec.ts` ("shows a TRPCClientError message as-is" — a directly-constructed `TRPCClientError` has `data == null`, so `isServerUnreachable` classifies it as an outage and returns the unreachable message; spec predates the outage-message commit `303d096f`) and `layout/sidebar/sidebar.spec.ts` ("should honor collapse state…" — stale since the mobile-nav rework `fa816a4e`).
+- ~~`nx test backend` has 18 pre-existing failing tests (web-forms/events/volunteer-events public-submission specs)~~ — fixed; those all pass as of 2026-07-24. `job-claim.spec.ts` can still fail in the full parallel run but passes in isolation (test-parallelism flake).
+- ~~`nx test frontend` has **2 pre-existing failing tests** (`services/api/user-message.spec.ts`, `layout/sidebar/sidebar.spec.ts`)~~ — both pass as of 2026-07-25; `nx run-many -t test -p frontend backend common uxcommon` is fully green (1188 tests).
+- ~~Deploy CI has **no test step**, which is how broken specs land on main.~~ — fixed 2026-07-25, see below.
+
+## CI runs this gate now (2026-07-25)
+
+`.github/workflows/verify.yml` runs **lint / test / build / e2e-smoke** on every PR, and `deploy.yml`
+declares `needs: verify`, so a red gate blocks the production deploy. Before this, `deploy.yml` went
+from `npm ci` straight to a rollout with no verification at all — which is exactly how the
+`frontend-e2e` suite reached **45/55 failing** without anyone noticing.
+
+Things worth knowing about that workflow:
+
+- **The `lint` job runs both lint paths**, for the disjoint-rule-set reason this whole skill is
+  about. The root-config step is scoped to **changed files** (same as the hook) because the repo has
+  13 pre-existing root-config errors in 6 files — `@angular-eslint/no-input-rename` in
+  `sticky-pin.directive.ts`, `no-output-native` in the two datagrid filters + `side-drawer` +
+  `tagitem`, and `no-undef` in `apps/website/tools/social/render.mjs`. Clearing those means renaming
+  public component inputs/outputs and updating every template that binds them. Once they're fixed,
+  that step can go repo-wide.
+- **The `test` job provisions a real Postgres** and reuses `apps/backend/scripts/setup-test-db.sh`,
+  so it follows automatically if the role model changes. It also sets `ALLOW_MOCK_PAYMENTS` and
+  `ALLOW_MOCK_DOMAIN_VERIFICATION` — both fail closed, and `settings/controller.spec.ts` asserts
+  against the latter.
+- **The `e2e` job gates on `@smoke`-tagged tests only.** Only `signin.spec.ts` is repaired and
+  tagged; `persons-grid`, `email-client`, `volunteer-events` and `web-forms` are still written
+  against pre-two-step-signin UI (**33 failing**) and stay out of the gate until repaired. Tag a test
+  `@smoke` once it's verified green and covers a journey worth blocking a deploy for.
+- **`prettier --check .` is deliberately NOT a CI gate.** `deploy/GO-LIVE-CHECKLIST.md` is
+  non-idempotent under prettier (it oscillates between two indent levels on a deeply-nested code
+  fence), so the check can never go green. The hook formats changed files, which is enough.
 - Stray `vitest` worker processes from an interrupted run can hold test-DB connections and make subsequent backend runs hang until timeout — `pkill -f vitest` before rerunning.
 
 The other hook step is formatting only:

--- a/.claude/skills/pplcrm-tenant-safety/SKILL.md
+++ b/.claude/skills/pplcrm-tenant-safety/SKILL.md
@@ -59,6 +59,33 @@ The lint rule still matters: RLS is a backstop, not a license to drop `.where('t
 scoping in app code (clearer intent, better plans, and it's the _only_ protection on the REST/worker
 paths). The rest of this doc is about that lint rule.
 
+## The third layer: the API-level IDOR probe
+
+`apps/backend/src/app/lib/tenant-isolation-api.spec.ts` (added 2026-07-25) is the test that covers
+what neither the lint rule nor the RLS spec does — **the surface an attacker actually reaches.** It
+builds a fully authenticated tRPC caller for tenant A (real `authusers` row + real active `sessions`
+row keyed by `hashToken(plaintext)`) and calls real procedures with tenant B's record IDs, so it
+exercises `isAuthed` → router → controller `.where('tenant_id', …)` → RLS in one path.
+
+Know the difference before adding to either file:
+
+| File                           | Proves                                                             |
+| ------------------------------ | ------------------------------------------------------------------ |
+| `rls-tenant-isolation.spec.ts` | the RLS **mechanism** works when bound via `runWithTenant`         |
+| `tenant-isolation-api.spec.ts` | the **API** refuses cross-tenant reads, writes and session replays |
+
+Two conventions to preserve if you extend it:
+
+- **Keep the control test.** It asserts tenant A _can_ read its own person. Without it, every denial
+  below could pass simply because the caller is broken — a probe that denies everything proves
+  nothing.
+- **Assert on data, not error codes.** Returning `undefined` and throwing `NOT_FOUND` are both
+  secure; returning B's row is the breach. Pinning a `TRPCError` code makes the spec brittle against
+  a legitimate refactor without making it a stronger security test.
+
+If you change tenant scoping anywhere, the honest check is whether this probe would still go red —
+it was mutation-tested (simulating a leak makes it fail), so a green run here is worth something.
+
 ## Where it lives and where it actually runs
 
 - Rule source: `tools/eslint-rules/rules/no-unscoped-db-query.cjs`

--- a/apps/backend/src/app/lib/tenant-isolation-api.spec.ts
+++ b/apps/backend/src/app/lib/tenant-isolation-api.spec.ts
@@ -1,0 +1,274 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { PersonsRouter } from '../modules/persons/trpc.router';
+import { HouseholdsRouter } from '../modules/households/trpc.router';
+import { BaseRepository } from './base.repo';
+import { hashToken } from './token-hash';
+
+/**
+ * Cross-tenant IDOR probe — the highest-stakes invariant in a multi-tenant CRM.
+ *
+ * This is deliberately NOT the same test as `rls-tenant-isolation.spec.ts`. That spec proves the
+ * Postgres RLS *mechanism* works when a tenant is bound via `runWithTenant`. This one attacks the
+ * surface an actual attacker reaches: a fully authenticated tRPC session for tenant A, calling
+ * real procedures with tenant B's record IDs. It exercises the whole stack the request takes —
+ * `isAuthed` (session lookup + `runWithTenant`), the router, the controller's app-level
+ * `.where('tenant_id', …)` filters, and the RLS policy underneath them.
+ *
+ * Why that distinction matters: the `local/no-unscoped-db-query` lint rule is explicitly "a
+ * tripwire, not a proof" (pplcrm-tenant-safety) and has documented blind spots — a query built
+ * across two statements, or scoped inside a subquery, passes lint while leaking. Only an
+ * end-to-end probe like this one can catch that class of bug.
+ *
+ * Assertion style: these tests assert that tenant B's DATA NEVER COMES BACK and is never mutated,
+ * rather than asserting a specific TRPCError code. Returning `undefined` and throwing NOT_FOUND
+ * are both secure; returning B's row is the breach. Pinning the error code would make the spec
+ * brittle against a legitimate refactor without making it any stronger as a security test.
+ *
+ * Callers are built with `createCaller`, which DOES run the `isAuthed` middleware — so each tenant
+ * needs a real `authusers` row and a real active `sessions` row whose `session_id` column holds
+ * the HASH of the plaintext token the context carries.
+ */
+const rand = (): string => String(Math.floor(Math.random() * 100000000) + 10000000);
+const db = BaseRepository.dbInstance;
+
+interface SeededTenant {
+  tenantId: string;
+  userId: string;
+  campaignId: string;
+  householdId: string;
+  personId: string;
+  /** Plaintext session token; the DB stores only its hash. */
+  sessionToken: string;
+  personFirstName: string;
+}
+
+async function seedTenant(label: string): Promise<SeededTenant> {
+  const tenantId = rand();
+  const userId = rand();
+  const campaignId = rand();
+  const householdId = rand();
+  const sessionToken = `idor-probe-${label}-${rand()}`;
+  const personFirstName = `Person-${label}-${rand()}`;
+
+  await db
+    .insertInto('tenants')
+    .values({ id: tenantId, name: `IDOR Probe ${label}` })
+    .execute();
+  await db
+    .insertInto('authusers')
+    .values({
+      id: userId,
+      tenant_id: tenantId,
+      email: `idor-${userId}@example.com`,
+      password: 'password',
+      first_name: 'Idor',
+      last_name: label,
+      verified: true,
+      // 'owner' deliberately: the strongest role, so a leak can never be attributed to some
+      // incidental role restriction rather than to genuine tenant scoping.
+      role: 'owner',
+      createdby_id: userId,
+      updatedby_id: userId,
+    })
+    .execute();
+  await db.updateTable('tenants').set({ admin_id: userId, createdby_id: userId }).where('id', '=', tenantId).execute();
+
+  await db
+    .insertInto('sessions')
+    .values({
+      id: rand(),
+      session_id: hashToken(sessionToken),
+      user_id: userId,
+      tenant_id: tenantId,
+      ip_address: '127.0.0.1',
+      status: 'active',
+      expires_at: new Date(Date.now() + 60 * 60 * 1000),
+    })
+    .execute();
+
+  await db
+    .insertInto('campaigns')
+    .values({
+      id: campaignId,
+      tenant_id: tenantId,
+      admin_id: userId,
+      name: `IDOR Campaign ${label}`,
+      kind: 'office',
+      createdby_id: userId,
+      updatedby_id: userId,
+    })
+    .execute();
+  await db
+    .insertInto('households')
+    .values({
+      id: householdId,
+      tenant_id: tenantId,
+      campaign_id: campaignId,
+      createdby_id: userId,
+      updatedby_id: userId,
+    })
+    .execute();
+
+  const person = await db
+    .insertInto('persons')
+    .values({
+      tenant_id: tenantId,
+      campaign_id: campaignId,
+      household_id: householdId,
+      first_name: personFirstName,
+      createdby_id: userId,
+      updatedby_id: userId,
+    })
+    .returning('id')
+    .executeTakeFirstOrThrow();
+
+  return {
+    tenantId,
+    userId,
+    campaignId,
+    householdId,
+    personId: String(person.id),
+    sessionToken,
+    personFirstName,
+  };
+}
+
+async function purgeTenant(t: SeededTenant): Promise<void> {
+  // The probe's own calls write activity rows, which FK-reference authusers — so these must go
+  // before the user, or teardown trips fk_user_activity_createdby.
+  await db.deleteFrom('user_activity').where('tenant_id', '=', t.tenantId).execute();
+  await db.deleteFrom('persons').where('tenant_id', '=', t.tenantId).execute();
+  await db.deleteFrom('households').where('tenant_id', '=', t.tenantId).execute();
+  await db.deleteFrom('campaigns').where('tenant_id', '=', t.tenantId).execute();
+  await db.deleteFrom('sessions').where('tenant_id', '=', t.tenantId).execute();
+  await db.updateTable('tenants').set({ admin_id: null, createdby_id: null }).where('id', '=', t.tenantId).execute();
+  await db.deleteFrom('authusers').where('tenant_id', '=', t.tenantId).execute();
+  await db.deleteFrom('tenants').where('id', '=', t.tenantId).execute();
+}
+
+/** The tRPC context a signed-in request carries, for the given seeded tenant. */
+function ctxFor(t: SeededTenant): { auth: { tenant_id: string; user_id: string; session_id: string } } {
+  return { auth: { tenant_id: t.tenantId, user_id: t.userId, session_id: t.sessionToken } };
+}
+
+/** Resolve whatever a call did — value or throw — into a single inspectable result. */
+async function settle<T>(p: Promise<T>): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> {
+  try {
+    return { ok: true, value: await p };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+/** Read a person straight from the DB, bypassing all app scoping, to verify real-world effect. */
+async function readPersonRaw(id: string): Promise<{ first_name: string | null } | undefined> {
+  return db.selectFrom('persons').select('first_name').where('id', '=', id).executeTakeFirst();
+}
+
+describe('Cross-tenant API isolation (IDOR probe)', () => {
+  let tenantA: SeededTenant;
+  let tenantB: SeededTenant;
+
+  beforeAll(async () => {
+    tenantA = await seedTenant('A');
+    tenantB = await seedTenant('B');
+  });
+
+  afterAll(async () => {
+    if (tenantA) await purgeTenant(tenantA);
+    if (tenantB) await purgeTenant(tenantB);
+  });
+
+  describe('control: the probe is actually wired up', () => {
+    // Without this, every assertion below could pass simply because the caller is broken —
+    // a test that denies everything proves nothing about isolation.
+    it('lets tenant A read its OWN person, so denials below are meaningful', async () => {
+      const caller = PersonsRouter.createCaller(ctxFor(tenantA));
+      const result = await settle(caller.getById(tenantA.personId));
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBeTruthy();
+        expect(result.value.first_name).toBe(tenantA.personFirstName);
+      }
+    });
+  });
+
+  describe('reads', () => {
+    it("never returns another tenant's person by direct id", async () => {
+      const caller = PersonsRouter.createCaller(ctxFor(tenantA));
+      const result = await settle(caller.getById(tenantB.personId));
+
+      // Throwing is fine. Returning B's row is the breach.
+      if (result.ok) {
+        expect(result.value ?? null).toBeNull();
+      }
+    });
+
+    it("never includes another tenant's persons in a list read", async () => {
+      const caller = PersonsRouter.createCaller(ctxFor(tenantA));
+      const result = await settle(caller.getAll({}));
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const rows: Array<{ id?: unknown; first_name?: unknown }> = Array.isArray(result.value)
+          ? result.value
+          : ((result.value as { rows?: Array<{ id?: unknown; first_name?: unknown }> })?.rows ?? []);
+        const ids = rows.map((r) => String(r.id));
+        const names = rows.map((r) => String(r.first_name));
+
+        expect(ids).not.toContain(tenantB.personId);
+        expect(names).not.toContain(tenantB.personFirstName);
+      }
+    });
+
+    it("never includes another tenant's households in a list read", async () => {
+      const caller = HouseholdsRouter.createCaller(ctxFor(tenantA));
+      const result = await settle(caller.getAll());
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const rows: Array<{ id?: unknown }> = Array.isArray(result.value)
+          ? result.value
+          : ((result.value as { rows?: Array<{ id?: unknown }> })?.rows ?? []);
+        expect(rows.map((r) => String(r.id))).not.toContain(tenantB.householdId);
+      }
+    });
+  });
+
+  describe('writes', () => {
+    it("never mutates another tenant's person", async () => {
+      const caller = PersonsRouter.createCaller(ctxFor(tenantA));
+      await settle(caller.update({ id: tenantB.personId, data: { first_name: 'PWNED' } }));
+
+      // Whether the call threw or silently no-op'd, B's row must be untouched.
+      const after = await readPersonRaw(tenantB.personId);
+      expect(after?.first_name).toBe(tenantB.personFirstName);
+    });
+
+    it("never deletes another tenant's person", async () => {
+      const caller = PersonsRouter.createCaller(ctxFor(tenantA));
+      await settle(caller.delete(tenantB.personId));
+
+      const after = await readPersonRaw(tenantB.personId);
+      expect(after).toBeTruthy();
+      expect(after?.first_name).toBe(tenantB.personFirstName);
+    });
+  });
+
+  describe('session binding', () => {
+    it("rejects a valid session token replayed against another tenant's id", async () => {
+      // The classic forged-context attack: real credentials, swapped tenant_id. The session
+      // lookup in `isAuthed` is itself tenant-scoped, so this must fail authentication rather
+      // than silently granting access to tenant B.
+      const forged = {
+        auth: { tenant_id: tenantB.tenantId, user_id: tenantA.userId, session_id: tenantA.sessionToken },
+      };
+      const caller = PersonsRouter.createCaller(forged);
+      const result = await settle(caller.getById(tenantB.personId));
+
+      expect(result.ok).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Follows #88. Now that CI actually runs tests, this adds the highest-stakes test I could write for a multi-tenant CRM.

## What's missing today

`rls-tenant-isolation.spec.ts` proves the Postgres RLS **mechanism** works when a tenant is bound via `runWithTenant`. It does not exercise the surface an attacker actually reaches: **an authenticated tRPC session for tenant A calling real procedures with tenant B's record IDs.**

This probe covers the whole request path — `isAuthed` (session lookup + `runWithTenant`) → router → controller `.where('tenant_id', …)` filters → the RLS policy beneath them.

| Vector | Assertion |
| --- | --- |
| Reads | `persons.getById`, `persons.getAll`, `households.getAll` never surface B's rows |
| Writes | `update` / `delete` against B's id never mutate B's row (verified by reading B's row back raw) |
| Session | A's *valid* session token replayed with B's `tenant_id` fails authentication |

## Why it's worth having

`local/no-unscoped-db-query` is documented in `pplcrm-tenant-safety` as **"a tripwire, not a proof"**, with known blind spots — a query built across two statements, or scoped inside a subquery, passes lint while leaking. Only an end-to-end probe catches that class.

## Two deliberate design choices

1. **A control test** asserts tenant A *can* read its own person — so the denials can't pass merely because the caller is broken.
2. **Assertions check that B's data never comes back / is never mutated**, rather than pinning a `TRPCError` code. `undefined` and `NOT_FOUND` are both secure; returning B's row is the breach. Pinning the code would be brittle without being stronger.

## Validated by mutation testing

A test that passes because it's inert is worse than none, so I verified the assertions discriminate: pointing the cross-tenant read at B's *own* caller (simulating a leak) makes the probe fail with `expected { id: '2', …(30) } to be null`. It goes red when isolation breaks.

Full backend suite: **1022 passing** (+7), no parallel interference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)