### PR TITLE
fix(frontend): reload once when a lazy route chunk will not import

### DIFF
--- a/.claude/skills/pplcrm-debugging/SKILL.md
+++ b/.claude/skills/pplcrm-debugging/SKILL.md
@@ -115,6 +115,18 @@ Fastify's per-request logger), so correlate a tRPC failure by **timestamp + stac
    If data silently fails to appear with no toast, check the browser console for a swallowed
    `.catch` before assuming the request never fired.
 
+4. **A preloaded chunk that failed to import poisons that route for the whole session.** `app.config.ts`
+   uses `withPreloading(PreloadAllModules)`, so every lazy route is `import()`ed in the background after
+   first paint — and Angular's `PreloadAllModules` swallows preload failures (`catchError(() => of(null))`).
+   Per the module spec a failed module URL stays failed in the document's module map, so the user's later
+   click on that route fails **instantly, with no network request**, while the chunk is perfectly healthy on
+   the server. On app.pplcrm.com (Cloudflare Pages, `/*  /index.html  200`) a momentarily missing chunk comes
+   back as HTML, so the symptom reads `Failed to load module script: … MIME type of "text/html"` followed by
+   `TypeError: Failed to fetch dynamically imported module: …/chunk-XXXX.js`. Don't go hunting the deploy —
+   `curl -I` the chunk first; it usually 200s. `apps/frontend/src/app/routing/stale-bundle.ts` recognises
+   all four engines' wording; `withNavigationErrorHandler` hard-loads the target URL once (a fresh document
+   is the only cure), and `ErrorService` shows `STALE_BUNDLE_MESSAGE` when the one-per-30s claim is refused.
+
 ## Non-goals
 
 - **TRPCError codes / how to throw them / transaction & outbox conventions** → `pplcrm-trpc-backend`.

--- a/apps/frontend/STRUCTURE.md
+++ b/apps/frontend/STRUCTURE.md
@@ -466,6 +466,7 @@ apps/
         routing/
           public-routes.ts
           route-reuse-strategy.ts
+          stale-bundle.ts
         services/
           api/
             abstract-api.service.ts

--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -8,6 +8,7 @@ import {
   TitleStrategy,
   provideRouter,
   withComponentInputBinding,
+  withNavigationErrorHandler,
   withPreloading,
 } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
@@ -20,6 +21,7 @@ import { CustomRouteReuseStrategy } from './routing/route-reuse-strategy';
 import { AuthService } from 'apps/frontend/src/app/auth/auth-service';
 import { jsendInterceptor } from './services/jsend.interceptor';
 import { GlobalErrorHandler } from './services/global-error-handler';
+import { claimReloadForStaleBundle, isStaleBundleError } from './routing/stale-bundle';
 
 export function initSession(authService: AuthService) {
   return async () => {
@@ -52,7 +54,19 @@ export const appConfig: ApplicationConfig = {
     },
     // Preload lazy route chunks in the background after first paint so slow
     // connections don't stall on chunk download at click time.
-    provideRouter(appRoutes, withComponentInputBinding(), withPreloading(PreloadAllModules)),
+    provideRouter(
+      appRoutes,
+      withComponentInputBinding(),
+      withPreloading(PreloadAllModules),
+      // A navigation that died because its chunk would not import can only be rescued by a fresh
+      // document — the failed module URL is stuck in this document's module map, so retrying the
+      // same route in-page fails instantly (see routing/stale-bundle.ts). Hard-load the URL the
+      // user was going to; when the claim is refused, ErrorService says so instead.
+      withNavigationErrorHandler((event) => {
+        if (!isStaleBundleError(event.error) || !claimReloadForStaleBundle()) return;
+        window.location.assign(event.url);
+      }),
+    ),
 
     provideZonelessChangeDetection(),
 

--- a/apps/frontend/src/app/routing/stale-bundle.spec.ts
+++ b/apps/frontend/src/app/routing/stale-bundle.spec.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { claimReloadForStaleBundle, isStaleBundleError } from './stale-bundle';
+
+describe('isStaleBundleError', () => {
+  it.each([
+    ['Chrome', 'Failed to fetch dynamically imported module: https://app.pplcrm.com/chunk-BJHSTgRT.js'],
+    ['Firefox', 'error loading dynamically imported module'],
+    ['Safari', 'Importing a module script failed.'],
+    [
+      'Chrome MIME refusal',
+      'Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html".',
+    ],
+  ])('recognises the %s wording', (_engine, message) => {
+    expect(isStaleBundleError(new TypeError(message))).toBe(true);
+  });
+
+  it('recognises a bare string message', () => {
+    expect(isStaleBundleError('Failed to fetch dynamically imported module: /chunk-a.js')).toBe(true);
+  });
+
+  it('leaves unrelated errors alone', () => {
+    expect(isStaleBundleError(new Error('Failed to fetch'))).toBe(false);
+    expect(isStaleBundleError(new TypeError('x is not a function'))).toBe(false);
+    expect(isStaleBundleError(null)).toBe(false);
+    expect(isStaleBundleError({ message: 'Failed to fetch dynamically imported module' })).toBe(false);
+  });
+});
+
+describe('claimReloadForStaleBundle', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('grants the first reload', () => {
+    expect(claimReloadForStaleBundle()).toBe(true);
+  });
+
+  it('refuses a second reload inside the cooldown, so a missing chunk cannot loop', () => {
+    expect(claimReloadForStaleBundle()).toBe(true);
+    vi.advanceTimersByTime(5_000);
+    expect(claimReloadForStaleBundle()).toBe(false);
+  });
+
+  it('grants again once the cooldown has passed', () => {
+    expect(claimReloadForStaleBundle()).toBe(true);
+    vi.advanceTimersByTime(31_000);
+    expect(claimReloadForStaleBundle()).toBe(true);
+  });
+
+  it('refuses when sessionStorage is unavailable — without a marker there is no loop guard', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('denied');
+    });
+    expect(claimReloadForStaleBundle()).toBe(false);
+  });
+});

--- a/apps/frontend/src/app/routing/stale-bundle.ts
+++ b/apps/frontend/src/app/routing/stale-bundle.ts
@@ -1,0 +1,68 @@
+/**
+ * Recovery for a lazy-route chunk the browser could not import.
+ *
+ * Every dynamic `import()` in this app is a lazy route, and every chunk filename is content-hashed,
+ * so a deploy replaces the whole set at once. app.pplcrm.com is a Cloudflare Pages site whose
+ * `/*  /index.html  200` SPA fallback answers a missing asset with HTML rather than a 404, so a
+ * request for a chunk that is momentarily unavailable comes back as a page — which the browser
+ * rejects with "Expected a JavaScript-or-Wasm module script but the server responded with a MIME
+ * type of text/html", surfacing to us as a `TypeError`.
+ *
+ * Two things make this outlive the moment it happens:
+ *
+ * 1. `withPreloading(PreloadAllModules)` imports every lazy chunk in the background after first
+ *    paint, and Angular's `PreloadAllModules` swallows preload failures (`catchError(() => of(null))`).
+ *    So a single hiccup during that burst is invisible.
+ * 2. Per the module spec, a module URL that failed to load stays failed in the document's module
+ *    map. The later real navigation re-runs the same `import()` and fails instantly — no retry, no
+ *    network request — with the server perfectly healthy.
+ *
+ * Retrying in-page therefore cannot work; only a fresh document can. Hence a hard navigation, and
+ * a one-per-cooldown claim so a genuinely missing chunk cannot turn into a reload loop.
+ */
+
+/** Shown when the app could not load a page's code and a hard reload was not available. */
+export const STALE_BUNDLE_MESSAGE =
+  'That page could not be loaded. Refresh the page to pick up the latest version of the app.';
+
+/** How the four engines word a failed dynamic `import()`, lowercased. */
+const STALE_BUNDLE_MESSAGES = [
+  'failed to fetch dynamically imported module', // Chrome / Edge
+  'error loading dynamically imported module', // Firefox
+  'importing a module script failed', // Safari
+  'failed to load module script', // Chrome, when the response MIME type is wrong
+] as const;
+
+const RELOAD_MARKER_KEY = 'pplcrm.stale-bundle-reload';
+
+/**
+ * Long enough to outlast one reload-and-navigate cycle (so a chunk that is genuinely gone from the
+ * deployment reloads once and then reports itself), short enough that a second, unrelated failure
+ * minutes later still self-heals.
+ */
+const RELOAD_COOLDOWN_MS = 30_000;
+
+/** True when `error` is the browser refusing a lazy chunk, whatever engine phrased it. */
+export function isStaleBundleError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  if (!message) return false;
+  const lowered = message.toLowerCase();
+  return STALE_BUNDLE_MESSAGES.some((known) => lowered.includes(known));
+}
+
+/**
+ * Asks for permission to hard-reload, recording the attempt so the next one inside the cooldown is
+ * refused. Returns false when the caller must tell the user instead — either a reload just
+ * happened (so reloading again would loop) or `sessionStorage` is unavailable, which leaves no way
+ * to tell a first failure from a loop.
+ */
+export function claimReloadForStaleBundle(): boolean {
+  try {
+    const last = Number(sessionStorage.getItem(RELOAD_MARKER_KEY));
+    if (Number.isFinite(last) && Date.now() - last < RELOAD_COOLDOWN_MS) return false;
+    sessionStorage.setItem(RELOAD_MARKER_KEY, String(Date.now()));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/frontend/src/app/services/error.service.spec.ts
+++ b/apps/frontend/src/app/services/error.service.spec.ts
@@ -7,6 +7,7 @@ import { JSendServerError } from '../../../../../libs/common/src';
 import { ApiError } from './api/api-error';
 import { TokenService } from './api/token-service';
 import { SERVER_UNREACHABLE_MESSAGE } from './api/user-message';
+import { STALE_BUNDLE_MESSAGE } from '../routing/stale-bundle';
 import { ErrorService } from './error.service';
 
 const FALLBACK = 'Something went wrong, please try again';
@@ -145,6 +146,12 @@ describe('ErrorService', () => {
       service.handle(new Error('Pick a campaign first'));
 
       expect(mockAlerts.showError).toHaveBeenCalledWith('Pick a campaign first');
+    });
+
+    it('names the real problem for a chunk that would not import — "try again" would never work', () => {
+      service.handle(new TypeError('Failed to fetch dynamically imported module: /chunk-BJHSTgRT.js'));
+
+      expect(mockAlerts.showError).toHaveBeenCalledWith(STALE_BUNDLE_MESSAGE);
     });
   });
 

--- a/apps/frontend/src/app/services/error.service.ts
+++ b/apps/frontend/src/app/services/error.service.ts
@@ -8,6 +8,7 @@ import { SERVER_UNREACHABLE_MESSAGE, getUserErrorMessage, isServerUnreachable } 
 
 import { TokenService } from './api/token-service';
 import { isCurrentRoutePublic } from '../routing/public-routes';
+import { STALE_BUNDLE_MESSAGE, isStaleBundleError } from '../routing/stale-bundle';
 
 /**
  * Window after a 401 sign-out redirect during which we (a) dedupe further 401s into the same
@@ -71,6 +72,14 @@ export class ErrorService {
         return;
       }
       this.alerts.showError(error.message);
+      return;
+    }
+
+    // A lazy-route chunk the browser refused to import. app.config.ts already tried to rescue the
+    // navigation with a hard reload; reaching here means it declined (a reload just happened, or
+    // storage is unavailable), so tell the user the one thing that actually helps.
+    if (isStaleBundleError(error)) {
+      this.alerts.showError(STALE_BUNDLE_MESSAGE);
       return;
     }
 


### PR DESCRIPTION
A user hit "Failed to fetch dynamically imported module: /chunk-BJHSTgRT.js" on app.pplcrm.com while every chunk in that deployment was serving fine (all 165 verified with curl). The cause is on the client, not the deploy:

  1. withPreloading(PreloadAllModules) import()s all ~90 lazy routes in the background after first paint.
  2. Angular's PreloadAllModules is fn().pipe(catchError(() => of(null))), so a failure in that burst is swallowed with no console trace.
  3. Per the module spec a module URL that failed stays failed in the document's module map. The user's later click on that route fails instantly, with no network request, against a healthy server.

Cloudflare Pages' `/*  /index.html  200` fallback is why the momentary miss arrives as HTML instead of a 404, which is what the browser's MIME complaint is reporting.

Retrying in-page cannot work, so a navigation killed this way now hard-loads the URL the user was going to; only a fresh document gets a clean module map and the current index.html. claimReloadForStaleBundle() grants one reload per 30 seconds so a chunk that really is missing from the deployment reloads once and then reports itself instead of looping. When the claim is refused, ErrorService says "Refresh the page to pick up the latest version" rather than "Something went wrong, please try again" — advice that could never work for this failure.

Also recorded as silent-failure trap #4 in the pplcrm-debugging skill, with the curl-the-chunk-first shortcut that rules out the deploy in one command.